### PR TITLE
feat: replace manual validation with Zod schemas

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -123,7 +123,7 @@ npm install --save-dev jest @types/jest ts-jest
 
 ### 8. Massive code duplication in config validation
 **File:** `src/Utils/GetAndValidateConfigs.ts`
-**Status:** TODO
+**Status:** DONE (PR #398) - Replaced with Zod schemas
 **Description:** The 3 validation methods repeat the same pattern ~20 times. Extract to helper functions.
 ```typescript
 // CREATE HELPER
@@ -285,7 +285,7 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 **Description:** Show progress when processing multiple lists (e.g., "Processing 3/10 lists...").
 
 ### 20. Add configuration schema validation
-**Status:** TODO
+**Status:** DONE (PR #398)
 **Description:** Use JSON Schema or Zod for declarative config validation instead of manual checks.
 
 ### 21. Add Docker Compose for development
@@ -340,15 +340,15 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 
 ## Summary
 
-| Priority | Count | Done | Remaining |
-|----------|-------|------|-----------|
-| Critical | 3 | 3 | 0 |
-| High | 4 | 3 | 1 |
-| Medium | 5 | 0 | 5 |
-| Low | 5 | 0 | 5 |
-| Features | 5 | 0 | 5 |
-| GitHub Issues | 6 | 0 | 6 |
-| **Total** | **28** | **6** | **22** |
+| Priority      | Count  | Done  | Remaining |
+|---------------|--------|-------|-----------|
+| Critical      | 3      | 3     | 0         |
+| High          | 4      | 3     | 1         |
+| Medium        | 5      | 1     | 4         |
+| Low           | 5      | 0     | 5         |
+| Features      | 5      | 1     | 4         |
+| GitHub Issues | 6      | 0     | 6         |
+| **Total**     | **28** | **8** | **20**    |
 
 ## Recommended Order of Implementation
 
@@ -358,7 +358,8 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 4. ~~Add Axios timeout (#4)~~ DONE
 5. ~~Fix FlixPatrolPopular type (#5)~~ DONE
 6. ~~Add try-catch around JSON.parse (#6)~~ DONE
-7. Extract name normalization helper (#10)
-8. Add retry logic (#11)
-9. Refactor config validation (#8)
-10. Add test framework (#7)
+7. ~~Refactor config validation (#8)~~ DONE (Zod)
+8. ~~Add Zod schema validation (#20)~~ DONE
+9. Extract name normalization helper (#10)
+10. Add retry logic (#11)
+11. Add test framework (#7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "file-system-cache": "^2.4.7",
         "jsdom": "^27.2.0",
         "trakt.tv": "^8.2.0",
-        "winston": "^3.19.0"
+        "winston": "^3.19.0",
+        "zod": "^4.1.13"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -5258,6 +5259,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
+      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "file-system-cache": "^2.4.7",
     "jsdom": "^27.2.0",
     "trakt.tv": "^8.2.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "zod": "^4.1.13"
   },
   "pkg": {
     "assets": "build/tmp/*.css",

--- a/src/Trakt/TraktAPI.ts
+++ b/src/Trakt/TraktAPI.ts
@@ -12,12 +12,7 @@ import type {
 import Trakt from 'trakt.tv';
 import fs from 'fs';
 import { logger, Utils } from '../Utils';
-
-export interface TraktAPIOptions {
-  saveFile: string;
-  clientId: string;
-  clientSecret: string;
-}
+import type { TraktAPIOptions } from '../Utils/GetAndValidateConfigs';
 
 export type TraktTVId = number | null;
 export type TraktTVIds = number[];

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,13 @@
-
 import type { CacheOptions } from './Flixpatrol';
 import { FlixPatrol } from './Flixpatrol';
 import { logger, Utils } from './Utils';
-import type {FlixPatrolMostWatched, FlixPatrolPopular, FlixPatrolTop10} from './Utils/GetAndValidateConfigs';
+import type {
+  FlixPatrolMostWatched,
+  FlixPatrolPopular,
+  FlixPatrolTop10,
+  TraktAPIOptions,
+} from './Utils/GetAndValidateConfigs';
 import { GetAndValidateConfigs } from './Utils/GetAndValidateConfigs';
-import type { TraktAPIOptions } from './Trakt';
 import { TraktAPI } from './Trakt';
 
 Utils.ensureConfigExist();


### PR DESCRIPTION
## Summary
- Replace ~440 lines of manual validation with ~180 lines of Zod schemas
- Add `zod` dependency for declarative schema validation
- Centralize platform/location arrays in GetAndValidateConfigs (single source of truth)
- Types are now inferred from Zod schemas
- Cleaner, more readable error messages

## Changes
- `src/Utils/GetAndValidateConfigs.ts`: Complete rewrite with Zod schemas
- `src/Flixpatrol/FlixPatrol.ts`: Import arrays instead of duplicating them
- `src/Trakt/TraktAPI.ts`: Import TraktAPIOptions from GetAndValidateConfigs
- `src/app.ts`: Updated imports

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Valid config loads correctly
- [x] Invalid config shows Zod error messages