### PR TITLE
fix: false reduced list warning

### DIFF
--- a/src/Flixpatrol/FlixPatrol.ts
+++ b/src/Flixpatrol/FlixPatrol.ts
@@ -155,7 +155,10 @@ export class FlixPatrol {
     return {
       movies,
       shows,
-      rawCounts: { movies: moviesRaw.length, shows: showsRaw.length, }
+      rawCounts: {
+        movies: Math.min(moviesRaw.length, config.limit),
+        shows: Math.min(showsRaw.length, config.limit),
+      }
     };
   }
 


### PR DESCRIPTION
## Description
Fix false "reduced list" warning that was displayed even when the list was correctly limited by the configured limit.

The warning was comparing total FlixPatrol items against the final list, but the list is intentionally limited by `config.limit`. The warning should only appear when some items couldn't be found on Trakt.

Now `rawCounts` represents the number of items we attempted to convert (capped by limit) rather than total FlixPatrol items.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
Fixes #333