### PR TITLE
refactor: extract name normalization to Utils.getListName()

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -164,8 +164,8 @@ fs.writeFileSync('./config/default.json', JSON.stringify(defaultConfig, null, 2)
 
 ### 10. Duplicated name normalization logic
 **File:** `src/app.ts:31-39, 67-75, 98-109`
-**Status:** TODO
-**Description:** Same pattern repeated 3 times. Extract to utility function.
+**Status:** DONE
+**Description:** Same pattern repeated 4 times. Extracted to `Utils.getListName()` utility function.
 ```typescript
 // ADD TO Utils.ts
 function getListName(
@@ -339,11 +339,11 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 |---------------|--------|--------|-----------|
 | Critical      | 3      | 3      | 0         |
 | High          | 4      | 4      | 0         |
-| Medium        | 5      | 1      | 4         |
+| Medium        | 5      | 2      | 3         |
 | Low           | 5      | 1      | 4         |
 | Features      | 5      | 1      | 4         |
 | GitHub Issues | 6      | 6      | 0         |
-| **Total**     | **28** | **16** | **12**    |
+| **Total**     | **28** | **17** | **11**    |
 
 ## Recommended Order of Implementation
 
@@ -357,5 +357,5 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 8. ~~Add Zod schema validation (#20)~~ DONE
 9. ~~Add test framework (#7)~~ DONE (Vitest)
 10. ~~Replace process.exit() with errors (#15)~~ DONE
-11. Extract name normalization helper (#10)
+11. ~~Extract name normalization helper (#10)~~ DONE
 12. Add retry logic (#11)

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -6,6 +6,19 @@ export class Utils {
     return new Promise((resolve) => { setTimeout(resolve, time); });
   }
 
+  public static getListName(
+    config: { name?: string; normalizeName?: boolean },
+    defaultName: string
+  ): string {
+    if (config.name && config.normalizeName === false) {
+      return config.name;
+    }
+    if (config.name) {
+      return config.name.toLowerCase().replace(/\s+/g, '-');
+    }
+    return defaultName;
+  }
+
   public static ensureConfigExist() {
     if (!fs.existsSync('./config/default.json')) {
       logger.warn('Default configuration file doesn\'t exist, creating it and exit. Please edit the config file');

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,15 +46,8 @@ const trakt = new TraktAPI(traktOptions);
 trakt.connect().then(async () => {
 
   for (const top10 of flixPatrolTop10) {
-    let baseListName: string;
-    if (top10.name && top10.normalizeName === false) {
-      baseListName = top10.name;
-    }
-    else if (top10.name) {
-      baseListName = top10.name.toLowerCase().replace(/\s+/g, '-');
-    } else {
-      baseListName = `${top10.platform}-${top10.location}-top10-${top10.fallback === false ? 'without-fallback' : `with-${top10.fallback}-fallback`}`;
-    }
+    const defaultName = `${top10.platform}-${top10.location}-top10-${top10.fallback === false ? 'without-fallback' : `with-${top10.fallback}-fallback`}`;
+    const baseListName = Utils.getListName(top10, defaultName);
 
     const { movies, shows, rawCounts } = await flixpatrol.getTop10Sections(top10, trakt);
 
@@ -82,15 +75,7 @@ trakt.connect().then(async () => {
 
 
   for (const popular of flixPatrolPopulars) {
-    let listName: string;
-    if (popular.name && popular.normalizeName === false) {
-      listName = popular.name;
-    }
-    else if (popular.name) {
-      listName = popular.name.toLowerCase().replace(/\s+/g, '-');
-    } else {
-      listName = `${popular.platform}-popular`;
-    }
+    const listName = Utils.getListName(popular, `${popular.platform}-popular`);
 
     if (popular.type === 'movies' || popular.type === 'both') {
       logger.info('==============================');
@@ -113,17 +98,11 @@ trakt.connect().then(async () => {
 
   for (const mostWatched of flixPatrolMostWatched) {
     if (mostWatched.enabled) {
-      let listName: string;
-      if (mostWatched.name && mostWatched.normalizeName === false) {
-        listName = mostWatched.name;
-      } else if (mostWatched.name) {
-        listName = mostWatched.name.toLowerCase().replace(/\s+/g, '-');
-      } else {
-        listName = `most-watched-${mostWatched.year}-netflix`;
-        listName = mostWatched.original !== undefined ? `${listName}-original` : listName;
-        listName = mostWatched.premiere !== undefined ? `${listName}-${mostWatched.premiere}-premiere` : listName;
-        listName = mostWatched.country !== undefined ? `${listName}-from-${mostWatched.country}` : listName;
-      }
+      let defaultName = `most-watched-${mostWatched.year}-netflix`;
+      defaultName = mostWatched.original !== undefined ? `${defaultName}-original` : defaultName;
+      defaultName = mostWatched.premiere !== undefined ? `${defaultName}-${mostWatched.premiere}-premiere` : defaultName;
+      defaultName = mostWatched.country !== undefined ? `${defaultName}-from-${mostWatched.country}` : defaultName;
+      const listName = Utils.getListName(mostWatched, defaultName);
 
       if (mostWatched.type === 'movies' || mostWatched.type === 'both') {
         logger.info('==============================');
@@ -147,17 +126,11 @@ trakt.connect().then(async () => {
 
   for (const mostHours of flixPatrolMostHours) {
     if (mostHours.enabled) {
-      let listName: string;
-      if (mostHours.name && mostHours.normalizeName === false) {
-        listName = mostHours.name;
-      } else if (mostHours.name) {
-        listName = mostHours.name.toLowerCase().replace(/\s+/g, '-');
-      } else {
-        listName = `netflix-most-hours-${mostHours.period}`;
-        if (mostHours.language !== 'all') {
-          listName += `-${mostHours.language}`;
-        }
+      let defaultName = `netflix-most-hours-${mostHours.period}`;
+      if (mostHours.language !== 'all') {
+        defaultName += `-${mostHours.language}`;
       }
+      const listName = Utils.getListName(mostHours, defaultName);
 
       if (mostHours.type === 'movies' || mostHours.type === 'both') {
         logger.info('==============================');

--- a/tests/Utils/Utils.test.ts
+++ b/tests/Utils/Utils.test.ts
@@ -67,6 +67,50 @@ describe('Utils', () => {
     });
   });
 
+  describe('getListName', () => {
+    it('should return custom name as-is when normalizeName is false', () => {
+      const config = { name: 'My Custom List', normalizeName: false };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('My Custom List');
+    });
+
+    it('should normalize custom name when normalizeName is not false', () => {
+      const config = { name: 'My Custom List' };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('my-custom-list');
+    });
+
+    it('should normalize custom name when normalizeName is true', () => {
+      const config = { name: 'My Custom List', normalizeName: true };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('my-custom-list');
+    });
+
+    it('should return default name when no custom name is provided', () => {
+      const config = {};
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('default-name');
+    });
+
+    it('should return default name when name is undefined', () => {
+      const config = { name: undefined };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('default-name');
+    });
+
+    it('should handle multiple spaces in name', () => {
+      const config = { name: 'My   Custom   List' };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('my-custom-list');
+    });
+
+    it('should handle leading and trailing spaces', () => {
+      const config = { name: '  My List  ' };
+      const result = Utils.getListName(config, 'default-name');
+      expect(result).toBe('-my-list-');
+    });
+  });
+
   describe('ensureConfigExist', () => {
     it('should do nothing if config file exists', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);


### PR DESCRIPTION
## Description
Extract duplicated name normalization logic from `app.ts` into `Utils.getListName()` helper function. Reduces code duplication from 4 similar blocks to a single reusable utility.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
None