### PR TITLE
ci: skip deploy on docs-only changes

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -3,6 +3,10 @@ name: Deploy Develop
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Description
Skip the develop deploy workflow when only documentation files are modified:
- `**.md` (all markdown files)
- `LICENSE`
- `.gitignore`

This avoids unnecessary builds and Docker image pushes for documentation-only changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
None