### PR TITLE
feat: add dry-run mode via DRY_RUN env var

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -274,8 +274,9 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 ## Feature Requests
 
 ### 18. Add dry-run mode
-**Status:** TODO
+**Status:** DONE
 **Description:** Allow running without actually updating Trakt lists, just logging what would be done.
+**Implementation:** Environment variable `DRY_RUN=true`. Modified `TraktAPI.ts` to skip write operations and log `[DRY-RUN]` messages instead.
 
 ### 19. Add progress indicators
 **Status:** TODO
@@ -341,9 +342,9 @@ let results = FlixPatrol.parsePopularPage(html);  // Remove !
 | High          | 4      | 4      | 0         |
 | Medium        | 5      | 5      | 0         |
 | Low           | 5      | 5      | 0         |
-| Features      | 5      | 2      | 3         |
+| Features      | 5      | 3      | 2         |
 | GitHub Issues | 6      | 6      | 0         |
-| **Total**     | **28** | **25** | **3**     |
+| **Total**     | **28** | **26** | **2**     |
 
 ## Recommended Order of Implementation
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,28 @@ To get started with Flixpatrol Top 10 on Trakt for Docker, follow these simple s
 ### Environment variable
 You can pass some environment variables to the tool:
 
-| Name      | Description                 | Values                          | Default |
-|-----------|-----------------------------|---------------------------------|---------|
-| LOG_LEVEL | How verbose the log will be | error, warn, info, debug, silly | info    |
+| Name      | Description                              | Values                          | Default |
+|-----------|------------------------------------------|---------------------------------|---------|
+| LOG_LEVEL | How verbose the log will be              | error, warn, info, debug, silly | info    |
+| DRY_RUN   | Run without making changes to Trakt      | true, false                     | false   |
+
+#### Dry-Run Mode
+
+Run the tool without modifying Trakt lists. Useful for testing your configuration:
+
+```bash
+# Linux/macOS
+DRY_RUN=true ./flixpatrol-top10-linux-x64
+
+# Docker
+docker run --rm -e DRY_RUN=true -v "/path/to/config:/app/config" ghcr.io/navino16/flixpatrol-top10-on-trakt:latest
+```
+
+In dry-run mode:
+- FlixPatrol scraping runs normally
+- Trakt search for ID conversion runs normally
+- OAuth authentication runs normally
+- List creation, item addition/removal, and updates are **logged but not executed**
 
 ### Configuration file
 The configuration file should be stored in a directory named `config` next to the binary.

--- a/src/Trakt/TraktAPI.ts
+++ b/src/Trakt/TraktAPI.ts
@@ -14,17 +14,24 @@ import fs from 'fs';
 import { logger, Utils, TraktError } from '../Utils';
 import type { TraktAPIOptions, TraktTVIds } from '../types';
 
+interface TraktAPIRuntimeOptions extends TraktAPIOptions {
+  dryRun?: boolean;
+}
+
 export class TraktAPI {
   private trakt: Trakt;
 
   private readonly traktSaveFile: string;
 
-  constructor(options: TraktAPIOptions) {
+  private readonly dryRun: boolean;
+
+  constructor(options: TraktAPIRuntimeOptions) {
     this.trakt = new Trakt({
       client_id: options.clientId,
       client_secret: options.clientSecret,
     });
     this.traktSaveFile = options.saveFile;
+    this.dryRun = options.dryRun ?? false;
   }
 
   public async connect(): Promise<void> {
@@ -63,11 +70,21 @@ export class TraktAPI {
 
   private async getList(listName: string, privacy: TraktPrivacy): Promise<TraktList> {
     let list: TraktList;
+    const slug = listName.toLowerCase().replace(/\s+/g, '-');
     try {
       logger.info(`Getting list "${listName}" from trakt`);
-      list = await this.trakt.users.list.get({ username: 'me', id: listName.toLowerCase().replace(/\s+/g, '-') });
+      list = await this.trakt.users.list.get({ username: 'me', id: slug });
     } catch (getErr) {
       if ((getErr as Error).message.includes('404 (Not Found)')) {
+        if (this.dryRun) {
+          logger.info(`[DRY-RUN] Would create list "${listName}" with privacy "${privacy}"`);
+          // Return a mock list object for dry-run mode
+          return {
+            name: listName,
+            privacy,
+            ids: { trakt: 0, slug },
+          } as TraktList;
+        }
         logger.warn(`List "${listName}" was not found on trakt, creating it`);
         try {
           // Avoid Trakt rate limit
@@ -85,6 +102,11 @@ export class TraktAPI {
   }
 
   private async getListItems(list: TraktList, type: TraktType): Promise<TraktItem[]> {
+    // In dry-run mode with mock list (id=0), return empty array
+    if (this.dryRun && list.ids.trakt === 0) {
+      logger.info(`[DRY-RUN] List "${list.name}" is new, no existing items to fetch`);
+      return [];
+    }
     logger.info(`Getting items from trakt list "${list.name}"`);
     let items: TraktItem[];
     try {
@@ -114,6 +136,10 @@ export class TraktAPI {
   }
 
   private async removeListItems(list: TraktList, items: TraktItem[], type: TraktType): Promise<void> {
+    if (this.dryRun) {
+      logger.info(`[DRY-RUN] Would remove ${items.length} ${type}(s) from list "${list.name}"`);
+      return;
+    }
     logger.info(`Trakt list "${list.name}" contain ${items.length} ${type}, removing them`);
     const toRemove: { ids: TraktIds }[] = [];
     items.forEach((item) => {
@@ -145,6 +171,10 @@ export class TraktAPI {
   }
 
   private async addItemsToList(list: TraktList, traktTVIDs: TraktTVIds, type: TraktType) {
+    if (this.dryRun) {
+      logger.info(`[DRY-RUN] Would add ${traktTVIDs.length} ${type}(s) to list "${list.name}"`);
+      return;
+    }
     logger.info(`Adding ${traktTVIDs.length} ${type} into Trakt list "${list.name}"`);
     const toAdd: { ids: TraktIds }[] = [];
     traktTVIDs.forEach((traktTVID) => {
@@ -177,10 +207,14 @@ export class TraktAPI {
   public async pushToList(traktTVIDs: TraktTVIds, listName: string, type: TraktType, privacy: TraktPrivacy) {
     let list = await this.getList(listName, privacy);
     if (list.privacy !== privacy) {
-      logger.warn(`Trakt list "${list.name}" privacy (${list.privacy}) doesn't match the wanted privacy (${privacy}), updating list privacy`);
-      // Avoid Trakt rate limit
-      await Utils.sleep(1000);
-      list = await this.trakt.users.list.update({ username: 'me', id: `${list.ids.slug}`, privacy });
+      if (this.dryRun) {
+        logger.info(`[DRY-RUN] Would update list "${list.name}" privacy from "${list.privacy}" to "${privacy}"`);
+      } else {
+        logger.warn(`Trakt list "${list.name}" privacy (${list.privacy}) doesn't match the wanted privacy (${privacy}), updating list privacy`);
+        // Avoid Trakt rate limit
+        await Utils.sleep(1000);
+        list = await this.trakt.users.list.update({ username: 'me', id: `${list.ids.slug}`, privacy });
+      }
     }
     const items = await this.getListItems(list, type);
     if (items.length > 0) {
@@ -188,14 +222,18 @@ export class TraktAPI {
     }
     if (traktTVIDs.length > 0) {
       await this.addItemsToList(list, traktTVIDs, type);
-      await Utils.sleep(1000);
       const dateOptions: Intl.DateTimeFormatOptions = {
         weekday: 'short', year: 'numeric', day: 'numeric', month: 'long', hour: '2-digit', minute: '2-digit', hour12: false, timeZoneName: 'short',
       };
-      const currentDate = new Date().toLocaleString(undefined, dateOptions); // Get the current date and time
-      const updatedString = `Last Updated: ${currentDate}`; // Concatenate the string with the current date and time
-      logger.info(`Updating list description: "${updatedString}"`);
-      await this.trakt.users.list.update({ username: 'me', id: `${list.ids.slug}`, description: updatedString });
+      const currentDate = new Date().toLocaleString(undefined, dateOptions);
+      const updatedString = `Last Updated: ${currentDate}`;
+      if (this.dryRun) {
+        logger.info(`[DRY-RUN] Would update list description to: "${updatedString}"`);
+      } else {
+        await Utils.sleep(1000);
+        logger.info(`Updating list description: "${updatedString}"`);
+        await this.trakt.users.list.update({ username: 'me', id: `${list.ids.slug}`, description: updatedString });
+      }
     }
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,15 @@ import type {
 import { GetAndValidateConfigs } from './Utils/GetAndValidateConfigs';
 import { TraktAPI } from './Trakt';
 
+const dryRun = process.env.DRY_RUN === 'true';
+
+if (dryRun) {
+  logger.info('========================================');
+  logger.info('DRY-RUN MODE ENABLED');
+  logger.info('No changes will be made to Trakt lists.');
+  logger.info('========================================');
+}
+
 Utils.ensureConfigExist();
 
 let cacheOptions: CacheOptions;
@@ -41,7 +50,7 @@ logger.silly(`flixPatrolMostWatched: ${JSON.stringify(flixPatrolMostWatched)}`);
 logger.silly(`flixPatrolMostHours: ${JSON.stringify(flixPatrolMostHours)}`);
 
 const flixpatrol = new FlixPatrol(cacheOptions);
-const trakt = new TraktAPI(traktOptions);
+const trakt = new TraktAPI({ ...traktOptions, dryRun });
 
 trakt.connect().then(async () => {
 
@@ -54,7 +63,7 @@ trakt.connect().then(async () => {
     if (movies.length > 0) {
       logger.info('==============================');
       if (rawCounts.movies > movies.length) {
-        logger.warn(`Flixpatrol have more movies than wanted, list have been reduced from ${rawCounts.movies} to ${movies.length} movies`);
+        logger.warn(`Some movies from FlixPatrol could not be matched on Trakt (${rawCounts.movies} found, ${movies.length} matched)`);
       }
       logger.info(`Saving movies for "${baseListName}"`);
       logger.debug(`${top10.platform} movies: ${movies}`);
@@ -64,7 +73,7 @@ trakt.connect().then(async () => {
     if (shows.length > 0) {
       logger.info('==============================');
       if (rawCounts.shows > shows.length) {
-        logger.warn(`Flixpatrol have more shows than wanted, list have been reduced from ${rawCounts.shows} to ${shows.length} shows`);
+        logger.warn(`Some shows from FlixPatrol could not be matched on Trakt (${rawCounts.shows} found, ${shows.length} matched)`);
       }
       logger.info(`Saving shows for "${baseListName}"`);
       logger.debug(`${top10.platform} shows: ${shows}`);


### PR DESCRIPTION
## Summary

- Add dry-run mode activated via `DRY_RUN=true` environment variable
- Skip all Trakt write operations (create list, add/remove items, update) when enabled
- Log `[DRY-RUN]` messages showing what would have been done
- Fix misleading warning message about unmatched movies/shows

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (lint passes)
- [x] Build passes