### PR TITLE
Reduce Popular platforms and make Trakt search errors non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 - Sync **Top 10 lists** from 72 streaming platforms (Netflix, Disney+, HBO Max, Amazon Prime, etc.)
 - Sync **Top 10 Kids lists** from Netflix (country-specific)
-- Sync **Popular lists** from 12 sources (IMDB, TMDB, Letterboxd, Rotten Tomatoes, etc.)
+- Sync **Popular lists** from 2 sources (Wikipedia and Youtube)
 - Sync **Netflix Most Watched** annual rankings
 - Sync **Netflix Most Hours** rankings (total, first week, first month)
 - Support for **200+ countries/regions**
@@ -244,7 +244,7 @@ If there is any configuration error, the tool will exit with information about t
   ],
   "FlixPatrolPopular": [
     {
-      "platform": "movie-db",
+      "platform": "wikipedia",
       "privacy": "private",
       "limit": 100,
       "type": "both"
@@ -320,7 +320,7 @@ To run this application you need a Trakt account and a Client ID / Client Secret
 
 ### Popular Sources (12)
 
-`facebook`, `imdb`, `instagram`, `letterboxd`, `movie-db`, `reddit`, `rotten-tomatoes`, `tmdb`, `trakt`, `twitter`, `wikipedia`, `youtube`
+`wikipedia`, `youtube`
 
 ### Locations (199)
 

--- a/config/default.json
+++ b/config/default.json
@@ -47,17 +47,11 @@
   ],
   "FlixPatrolPopular": [
     {
-      "platform": "movie-db",
+      "platform": "wikipedia",
       "privacy": "private",
       "limit": 100,
       "type": "both",
-      "name": "Most popular titles in Movie DBs"
-    },
-    {
-      "platform": "imdb",
-      "privacy": "private",
-      "limit": 100,
-      "type": "both"
+      "name": "Most popular titles in Wikipedia"
     }
   ],
   "FlixPatrolMostWatched": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/@yao-pkg/pkg/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2497,9 +2497,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3422,9 +3422,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4942,10 +4942,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -5653,9 +5654,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6161,9 +6162,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Trakt/TraktAPI.ts
+++ b/src/Trakt/TraktAPI.ts
@@ -239,11 +239,17 @@ export class TraktAPI {
 
   // eslint-disable-next-line max-len
   public async getFirstItemByQuery(searchType: TraktSearchType, title: string, year: number): Promise<TraktSearchItem | null> {
-    const items = await this.trakt.search.text({
-      type: searchType,
-      query: title,
-      fields: 'title',
-    });
+    let items: TraktSearchItem[];
+    try {
+      items = await this.trakt.search.text({
+        type: searchType,
+        query: title,
+        fields: 'title',
+      });
+    } catch (err) {
+      logger.warn(`Trakt search failed for ${searchType} "${title}" (${year}): ${(err as Error).message}. Skipping item.`);
+      return null;
+    }
 
     logger.silly(`Items found on Trakt: ${JSON.stringify(items)}`)
 

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -88,18 +88,12 @@ export class Utils {
         ],
         FlixPatrolPopular: [
           {
-            platform: 'movie-db',
-            name: 'Most popular titles in Movie DBs',
+            platform: 'wikipedia',
+            name: 'Most popular titles in Wikipedia',
             privacy: 'private',
             limit: 100,
             type: 'both',
-          },
-          {
-            platform: 'imdb',
-            privacy: 'private',
-            limit: 100,
-            type: 'both',
-          },
+          }
         ],
         FlixPatrolMostWatched: [
           {

--- a/src/types/Config.types.ts
+++ b/src/types/Config.types.ts
@@ -35,8 +35,7 @@ export const flixpatrolTop10Platform = ['9now', 'abema', 'amazon', 'amazon-chann
   'trueid', 'tubi', 'tv-2-norge', 'u-next', 'viaplay', 'videoland', 'vidio', 'viki', 'viu', 'vix', 'voyo', 'vudu',
   'watchit', 'wavve', 'wow', 'zee5'] as const;
 
-export const flixpatrolPopularPlatform = ['facebook', 'imdb', 'instagram', 'letterboxd', 'movie-db', 'reddit',
-  'rotten-tomatoes', 'tmdb', 'trakt', 'twitter', 'wikipedia', 'youtube'] as const;
+export const flixpatrolPopularPlatform = ['wikipedia', 'youtube'] as const;
 
 export const flixpatrolConfigType = ['movies', 'shows', 'both'] as const;
 const traktPrivacy = ['private', 'link', 'friends', 'public'] as const;

--- a/tests/Flixpatrol/FlixPatrol.test.ts
+++ b/tests/Flixpatrol/FlixPatrol.test.ts
@@ -59,10 +59,8 @@ describe('FlixPatrol', () => {
 
     describe('isFlixPatrolPopularPlatform', () => {
       it('should return true for valid popular platforms', () => {
-        expect(FlixPatrol.isFlixPatrolPopularPlatform('imdb')).toBe(true);
-        expect(FlixPatrol.isFlixPatrolPopularPlatform('trakt')).toBe(true);
-        expect(FlixPatrol.isFlixPatrolPopularPlatform('letterboxd')).toBe(true);
-        expect(FlixPatrol.isFlixPatrolPopularPlatform('movie-db')).toBe(true);
+        expect(FlixPatrol.isFlixPatrolPopularPlatform('wikipedia')).toBe(true);
+        expect(FlixPatrol.isFlixPatrolPopularPlatform('youtube')).toBe(true);
       });
 
       it('should return false for invalid popular platforms', () => {

--- a/tests/Trakt/TraktAPI.test.ts
+++ b/tests/Trakt/TraktAPI.test.ts
@@ -199,6 +199,16 @@ describe('TraktAPI', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should return null when Trakt search throws, without bubbling the error', async () => {
+      const trakt = new TraktAPI(mockOptions);
+      const traktInstance = (trakt as unknown as { trakt: { search: { text: ReturnType<typeof vi.fn> } } }).trakt;
+      traktInstance.search.text.mockRejectedValue(new Error('Response code 500 (Internal Server Error)'));
+
+      const result = await trakt.getFirstItemByQuery('movie', 'Trolls', 2016);
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('pushToList', () => {

--- a/tests/Utils/GetAndValidateConfigs.test.ts
+++ b/tests/Utils/GetAndValidateConfigs.test.ts
@@ -72,10 +72,8 @@ describe('GetAndValidateConfigs', () => {
 
     describe('flixpatrolPopularPlatform', () => {
       it('should contain popular rating platforms', () => {
-        expect(flixpatrolPopularPlatform).toContain('imdb');
-        expect(flixpatrolPopularPlatform).toContain('trakt');
-        expect(flixpatrolPopularPlatform).toContain('letterboxd');
-        expect(flixpatrolPopularPlatform).toContain('movie-db');
+        expect(flixpatrolPopularPlatform).toContain('wikipedia');
+        expect(flixpatrolPopularPlatform).toContain('youtube');
       });
 
       it('should not contain streaming platforms', () => {
@@ -174,7 +172,7 @@ describe('GetAndValidateConfigs', () => {
       it('should return valid FlixPatrolPopular config', () => {
         const validConfig = [
           {
-            platform: 'imdb',
+            platform: 'wikipedia',
             privacy: 'private',
             limit: 50,
             type: 'movies',


### PR DESCRIPTION
## Description

Two unrelated changes bundled:

1. **Refactor**: reduce FlixPatrol Popular platforms to `wikipedia` and `youtube` only (other sources were unreliable/deprecated). Updates `README.md`, `config/default.json`, `src/Utils/Utils.ts`, `src/types/Config.types.ts`.
2. **Bug fix**: a Trakt `search/movie` 500 error on a single title used to abort the whole run. Now caught in `TraktAPI.getFirstItemByQuery` — the title is skipped with a warning and processing continues on the remaining items/lists.

Root cause of the 500: reproduced against `GET /search/movie?query=Trolls` which consistently returns `500 Internal Server Error` from Trakt (`handler.search.getMedia`). Our payload is valid — the bug is server-side on Trakt, so we defensively handle it.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- none -->