### PR TITLE
Replace axios with impit to bypass Cloudflare bot protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
       "version": "2.14.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^1.16.1",
-        "axios-retry": "^4.5.0",
         "config": "^4.4.1",
         "file-system-cache": "^2.4.7",
+        "impit": "^0.14.0",
         "jsdom": "^29.1.1",
         "trakt.tv": "^8.2.0",
         "winston": "^3.19.0",
@@ -2186,6 +2185,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -2282,36 +2282,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
     },
     "node_modules/b4a": {
       "version": "1.8.0",
@@ -2587,19 +2557,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2762,18 +2719,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -2860,6 +2805,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2917,15 +2863,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2944,20 +2881,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -3003,57 +2926,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -3445,42 +3323,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3520,6 +3362,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3533,43 +3376,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3623,18 +3429,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/got": {
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
@@ -3673,37 +3467,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3752,6 +3520,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -3797,6 +3566,154 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/impit": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.14.0.tgz",
+      "integrity": "sha512-kxd8IUkzwajLIZiNIbRVcsry/mY7yQNhQ8XIcpKCZ3Sv9KirRMt7hbAwy3D5GBJNHvgHIplivHgnegQ7P87F6g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "impit-darwin-arm64": "0.14.0",
+        "impit-darwin-x64": "0.14.0",
+        "impit-linux-arm64-gnu": "0.14.0",
+        "impit-linux-arm64-musl": "0.14.0",
+        "impit-linux-x64-gnu": "0.14.0",
+        "impit-linux-x64-musl": "0.14.0",
+        "impit-win32-arm64-msvc": "0.14.0",
+        "impit-win32-x64-msvc": "0.14.0"
+      }
+    },
+    "node_modules/impit-darwin-arm64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.14.0.tgz",
+      "integrity": "sha512-I/v/raC+kx0dhiTZ7MTNtqDvYz9cuBZYrKR2g1YWsDSF16msTvjYc/4vEII5o7fBeUWyxzt9lC8Ef4HD3Lvi1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-darwin-x64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.14.0.tgz",
+      "integrity": "sha512-R4rxz8ub/L8B5rTdYa6uanzB5SotvbOYmSUbWM4lDcYCr/UWIkybTi9+MvIRMIoX3UI3KPvvrtDD11v+VO03Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-gnu": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.14.0.tgz",
+      "integrity": "sha512-JBjmjH8hGe+UJIDPKoS40GvRRfJrtFkGiUxupksTVdbAAI3+SVyhwBo1I6ave9Ig5QrMVpj6XWPUDbDepPdaCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-musl": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.14.0.tgz",
+      "integrity": "sha512-TPMa02wppWdlAqacrLT8qxM+EGoKi7b1mTUZLhWsjaSfweIsJmCCQygN/+eMZFT070pTcUNSTQBxzb3zBQKRQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-gnu": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.14.0.tgz",
+      "integrity": "sha512-VfaWq+YI5muQsM6cBoG4d+ltb0hzbJU4mj8PcG7M+Xe9Srq2jOIwoSQmgU9hhgnP9HKhiPTY/05Z8jvmllmZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-musl": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.14.0.tgz",
+      "integrity": "sha512-oGCJu11f0R5wSfB6HSCIUIZ8Fic/2JmBDioxifgxDtFJ9EEl2e4WinTD8woKNaS6LqwrIgUE9NJ4CXrwxCbrog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-arm64-msvc": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.14.0.tgz",
+      "integrity": "sha512-V/GJP5l4y3MGjMVJJXiZ09guQBvIDaDKdvONe+i8zpDbRopZLSRdWrsaTaiG/Nes2Iy7kS7q3eFgsV5ID45sPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-x64-msvc": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.14.0.tgz",
+      "integrity": "sha512-lgVnvVxUlNtyctPFjWUrWtTitK+aahwgn3YzeakODN2dVY5x7XOP1wg7XQjOg/AD6ydc40yBwWXyOf1hknGsHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -3906,18 +3823,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "license": "MIT"
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4462,41 +4367,11 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -5060,15 +4935,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "axios": "^1.16.1",
-    "axios-retry": "^4.5.0",
     "config": "^4.4.1",
     "file-system-cache": "^2.4.7",
+    "impit": "^0.14.0",
     "jsdom": "^29.1.1",
     "trakt.tv": "^8.2.0",
     "winston": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "npm run build && rm -rf bin/ && mkdir -p bin/ && npx ncc build build/app.js -o build/tmp && bash scripts/patch-ncc-bundle.sh && npx pkg --no-bytecode --public --config=package.json build/tmp/index.js && mv bin/flixpatrol-top10-linux-x64 bin/flixpatrol-top10-linux-amd64"
+    "package": "npm run build && rm -rf bin/ && mkdir -p bin/ && bash scripts/install-native-bindings.sh && npx ncc build build/app.js -o build/tmp && bash scripts/patch-ncc-bundle.sh && npx pkg --no-bytecode --public --config=package.json build/tmp/index.js && mv bin/flixpatrol-top10-linux-x64 bin/flixpatrol-top10-linux-amd64"
   },
   "keywords": [
     "Flixpatrol",
@@ -49,6 +49,7 @@
   "pkg": {
     "assets": [
       "build/tmp/*.css",
+      "build/tmp/*.node",
       "build/tmp/data/*.json",
       "build/tmp/node_modules/mdn-data/**/*.json"
     ],

--- a/scripts/install-native-bindings.sh
+++ b/scripts/install-native-bindings.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Force-install `impit`'s native bindings for every target packaged by `pkg`.
+# npm only installs the optional binding matching the host platform, so without this
+# step the cross-platform binaries produced by `pkg` would crash at startup with
+# "impit couldn't load native bindings".
+set -euo pipefail
+
+IMPIT_VERSION=$(node -p "require('./node_modules/impit/package.json').version")
+
+# Targets must match the `pkg.targets` entries in package.json.
+BINDINGS=(
+  "impit-linux-x64-gnu"
+  "impit-linux-arm64-gnu"
+  "impit-darwin-x64"
+  "impit-darwin-arm64"
+  "impit-win32-x64-msvc"
+)
+
+PACKAGES=()
+for pkg in "${BINDINGS[@]}"; do
+  PACKAGES+=("${pkg}@${IMPIT_VERSION}")
+done
+
+npm install --no-save --force --os=any --cpu=any "${PACKAGES[@]}"

--- a/src/Flixpatrol/FlixPatrol.ts
+++ b/src/Flixpatrol/FlixPatrol.ts
@@ -1,8 +1,6 @@
-import type {AxiosRequestConfig} from 'axios';
-import axios from 'axios';
-import axiosRetry from 'axios-retry';
 import { JSDOM } from 'jsdom';
 import Cache, { FileSystemCache } from 'file-system-cache';
+import { Impit } from 'impit';
 import { logger, FlixPatrolError } from '../Utils';
 import type { TraktTVId, TraktTVIds } from '../types';
 import { TraktAPI } from '../Trakt';
@@ -27,18 +25,8 @@ import {
   flixpatrolConfigType,
 } from '../types';
 
-// Configure axios-retry with exponential backoff
-axiosRetry(axios, {
-  retries: 3,
-  retryDelay: axiosRetry.exponentialDelay,
-  retryCondition: (error) => {
-    return axiosRetry.isNetworkOrIdempotentRequestError(error)
-      || error.response?.status === 429;
-  },
-  onRetry: (retryCount, error) => {
-    logger.warn(`Retry attempt ${retryCount} for ${error.config?.url}: ${error.message}`);
-  },
-});
+const RETRY_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_RETRIES = 3;
 
 type FlixPatrolMatchResult = string;
 
@@ -49,9 +37,12 @@ export class FlixPatrol {
 
   private readonly movieCache: FileSystemCache | null = null;
 
+  private readonly impit: Impit;
+
   constructor(cacheOptions: CacheOptions, options: FlixPatrolOptions = {}) {
     this.options.url = options.url || 'https://flixpatrol.com';
-    this.options.agent = options.agent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
+    // Use Impit with Chrome browser impersonation to bypass Cloudflare's TLS fingerprint check.
+    this.impit = new Impit({ browser: 'chrome', timeout: 30000 });
     if (cacheOptions.enabled) {
       this.tvCache = Cache({
         basePath: `${cacheOptions.savePath}/tv-shows`, // (optional) Path where cache files are stored (default).
@@ -88,24 +79,30 @@ export class FlixPatrol {
   public async getFlixPatrolHTMLPage(path: string): Promise<string | null> {
     const url = `${this.options.url}${path}`;
     logger.silly(`Accessing URL: ${url}`);
-    const axiosConfig: AxiosRequestConfig = {
-      headers: {
-        'User-Agent': this.options.agent,
-      },
-      timeout: 30000,
-    };
 
-    try {
-      const res = await axios.get(url, axiosConfig);
-      logger.silly(`Status code: ${res.status}`);
-      if (res.status !== 200) {
-        return null;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+      try {
+        const res = await this.impit.fetch(url);
+        logger.silly(`Status code: ${res.status}`);
+        if (res.status === 200) {
+          return await res.text();
+        }
+        if (!RETRY_STATUS_CODES.has(res.status) || attempt === MAX_RETRIES) {
+          return null;
+        }
+        logger.warn(`Retry attempt ${attempt} for ${url}: HTTP ${res.status}`);
+      } catch (error) {
+        if (attempt === MAX_RETRIES) {
+          logger.error(`Error getting flixPatrolHTMLPage: ${error}`);
+          return null;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`Retry attempt ${attempt} for ${url}: ${message}`);
       }
-      return res.data;
-    } catch (error) {
-      logger.error(`Error getting flixPatrolHTMLPage: ${error}`);
-      return null;
+      // Exponential backoff: 1s, 2s, 4s
+      await new Promise((resolve) => { setTimeout(resolve, 2 ** (attempt - 1) * 1000); });
     }
+    return null;
   }
 
   private static parseTop10Page(

--- a/src/types/FlixPatrol.types.ts
+++ b/src/types/FlixPatrol.types.ts
@@ -7,7 +7,6 @@ import {
 
 export interface FlixPatrolOptions {
   url?: string;
-  agent?: string;
 }
 
 // Types derived from the arrays

--- a/tests/Flixpatrol/FlixPatrol.test.ts
+++ b/tests/Flixpatrol/FlixPatrol.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FlixPatrol } from '../../src/Flixpatrol/FlixPatrol';
-import axios from 'axios';
 import type { FlixPatrolTop10, FlixPatrolPopular, FlixPatrolMostWatched, FlixPatrolMostHours } from '../../src/types';
 
-// Mock axios
-vi.mock('axios');
+// Mock impit: single shared `mockFetch` is returned from every `new Impit(...)`,
+// mirroring the previous `vi.mock('axios')` behavior where all instances shared one mock.
+const mockFetch = vi.fn();
+vi.mock('impit', () => ({
+  // Use a regular `function` (not an arrow) so it can be invoked with `new`.
+  Impit: vi.fn(function MockImpit(this: { fetch: typeof mockFetch }) {
+    this.fetch = mockFetch;
+  }),
+}));
+
+// Helper to build an impit-style response from the legacy { status, data } shape used by the tests.
+const mockHtmlResponse = (input: { status: number; data: unknown }) => ({
+  status: input.status,
+  text: async () => (input.data as string) ?? '',
+});
 
 // Mock file-system-cache
 vi.mock('file-system-cache', () => ({
@@ -95,7 +107,7 @@ describe('FlixPatrol', () => {
     it('should create FlixPatrol instance with custom options', () => {
       const flixpatrol = new FlixPatrol(
         { enabled: false, savePath: '', ttl: 0 },
-        { url: 'https://custom.url', agent: 'CustomAgent/1.0' }
+        { url: 'https://custom.url' }
       );
       expect(flixpatrol).toBeInstanceOf(FlixPatrol);
     });
@@ -115,30 +127,22 @@ describe('FlixPatrol', () => {
 
     it('should return HTML content on successful request', async () => {
       const mockHtml = '<html><body>Test content</body></html>';
-      vi.mocked(axios.get).mockResolvedValue({
+      mockFetch.mockResolvedValue(mockHtmlResponse({
         status: 200,
         data: mockHtml,
-      });
+      }));
 
       const result = await flixpatrol.getFlixPatrolHTMLPage('/test-path');
 
       expect(result).toBe(mockHtml);
-      expect(axios.get).toHaveBeenCalledWith(
-        'https://flixpatrol.com/test-path',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'User-Agent': expect.any(String),
-          }),
-          timeout: 30000,
-        })
-      );
+      expect(mockFetch).toHaveBeenCalledWith('https://flixpatrol.com/test-path');
     });
 
     it('should return null on non-200 status', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
+      mockFetch.mockResolvedValue(mockHtmlResponse({
         status: 404,
         data: 'Not found',
-      });
+      }));
 
       const result = await flixpatrol.getFlixPatrolHTMLPage('/not-found');
 
@@ -146,7 +150,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should return null on network error', async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error('Network error'));
+      mockFetch.mockRejectedValue(new Error('Network error'));
 
       const result = await flixpatrol.getFlixPatrolHTMLPage('/error-path');
 
@@ -159,40 +163,14 @@ describe('FlixPatrol', () => {
         { url: 'https://custom.flixpatrol.com' }
       );
 
-      vi.mocked(axios.get).mockResolvedValue({
+      mockFetch.mockResolvedValue(mockHtmlResponse({
         status: 200,
         data: '<html></html>',
-      });
+      }));
 
       await customFlixpatrol.getFlixPatrolHTMLPage('/test');
 
-      expect(axios.get).toHaveBeenCalledWith(
-        'https://custom.flixpatrol.com/test',
-        expect.any(Object)
-      );
-    });
-
-    it('should use custom User-Agent when provided', async () => {
-      const customFlixpatrol = new FlixPatrol(
-        { enabled: false, savePath: '', ttl: 0 },
-        { agent: 'MyCustomAgent/1.0' }
-      );
-
-      vi.mocked(axios.get).mockResolvedValue({
-        status: 200,
-        data: '<html></html>',
-      });
-
-      await customFlixpatrol.getFlixPatrolHTMLPage('/test');
-
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'User-Agent': 'MyCustomAgent/1.0',
-          }),
-        })
-      );
+      expect(mockFetch).toHaveBeenCalledWith('https://custom.flixpatrol.com/test');
     });
   });
 
@@ -223,10 +201,10 @@ describe('FlixPatrol', () => {
             </body>
           </html>
         `;
-        vi.mocked(axios.get).mockResolvedValue({
+        mockFetch.mockResolvedValue(mockHtmlResponse({
           status: 200,
           data: mockHtml,
-        });
+        }));
 
         // We can't directly test parseTop10Page since it's private
         // But we can verify getFlixPatrolHTMLPage returns the HTML
@@ -235,20 +213,20 @@ describe('FlixPatrol', () => {
       });
 
       it('should handle empty HTML gracefully', async () => {
-        vi.mocked(axios.get).mockResolvedValue({
+        mockFetch.mockResolvedValue(mockHtmlResponse({
           status: 200,
           data: '<html><body></body></html>',
-        });
+        }));
 
         const result = await flixpatrol.getFlixPatrolHTMLPage('/top10/netflix/world');
         expect(result).toBe('<html><body></body></html>');
       });
 
       it('should handle malformed HTML', async () => {
-        vi.mocked(axios.get).mockResolvedValue({
+        mockFetch.mockResolvedValue(mockHtmlResponse({
           status: 200,
           data: '<html><body><div>Not closed',
-        });
+        }));
 
         const result = await flixpatrol.getFlixPatrolHTMLPage('/top10/netflix/world');
         expect(result).toBe('<html><body><div>Not closed');
@@ -282,7 +260,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should throw FlixPatrolError when page fetch fails', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolTop10 = {
         platform: 'netflix',
@@ -328,9 +306,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Test Movie', year: 2024, ids: { trakt: 123 } },
@@ -382,9 +360,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Test Show', year: 2024, ids: { trakt: 456 } },
@@ -443,9 +421,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Test Movie', year: 2024, ids: { trakt: 123 } },
@@ -498,10 +476,10 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: emptyHtml })
-        .mockResolvedValueOnce({ status: 200, data: fallbackHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: emptyHtml }))
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: fallbackHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Fallback Movie', year: 2024, ids: { trakt: 789 } },
@@ -519,7 +497,7 @@ describe('FlixPatrol', () => {
       const result = await flixpatrol.getTop10Sections(config, mockTrakt as never);
 
       // Fallback should have been triggered
-      expect(axios.get).toHaveBeenCalledTimes(3); // Initial + fallback + detail
+      expect(mockFetch).toHaveBeenCalledTimes(3); // Initial + fallback + detail
     });
 
     it('should respect the limit configuration', async () => {
@@ -556,9 +534,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Test Movie', year: 2024, ids: { trakt: 123 } },
@@ -607,9 +585,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Regional Movie', year: 2024, ids: { trakt: 999 } },
@@ -662,9 +640,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Kids Movie', year: 2024, ids: { trakt: 1001 } },
@@ -716,9 +694,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: top10Html })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: top10Html }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Kids Show', year: 2024, ids: { trakt: 1002 } },
@@ -758,7 +736,7 @@ describe('FlixPatrol', () => {
       expect(result.rawCounts.movies).toBe(0);
       expect(result.rawCounts.shows).toBe(0);
       // Should not make any HTTP requests
-      expect(axios.get).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('should return empty results for kids with world location', async () => {
@@ -779,14 +757,14 @@ describe('FlixPatrol', () => {
       expect(result.rawCounts.movies).toBe(0);
       expect(result.rawCounts.shows).toBe(0);
       // Should not make any HTTP requests
-      expect(axios.get).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('should not trigger fallback for kids when no results found', async () => {
       const emptyHtml = '<html><body></body></html>';
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: emptyHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: emptyHtml }));
 
       const config: FlixPatrolTop10 = {
         platform: 'netflix',
@@ -801,7 +779,7 @@ describe('FlixPatrol', () => {
       const result = await flixpatrol.getTop10Sections(config, mockTrakt as never);
 
       // Fallback should NOT be triggered for kids
-      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.movies).toEqual([]);
       expect(result.shows).toEqual([]);
     });
@@ -817,10 +795,10 @@ describe('FlixPatrol', () => {
     });
 
     it('should throw FlixPatrolError when page fetch fails', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 10,
         type: 'movies',
@@ -864,16 +842,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Popular Movie', year: 2024, ids: { trakt: 111 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 10,
         type: 'movies',
@@ -913,16 +891,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Popular Show', year: 2024, ids: { trakt: 222 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 10,
         type: 'shows',
@@ -962,16 +940,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Movie', year: 2024, ids: { trakt: 100 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 2,
         type: 'movies',
@@ -993,7 +971,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should throw FlixPatrolError when page fetch fails', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolMostWatched = {
         enabled: true,
@@ -1036,9 +1014,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Most Watched Movie', year: 2024, ids: { trakt: 333 } },
@@ -1086,9 +1064,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Most Watched Show', year: 2024, ids: { trakt: 444 } },
@@ -1106,10 +1084,7 @@ describe('FlixPatrol', () => {
 
       expect(Array.isArray(result)).toBe(true);
       // TV shows URL should include -grouped
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('-grouped'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('-grouped'));
     });
 
     it('should include country in URL when specified', async () => {
@@ -1141,9 +1116,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Movie', year: 2024, ids: { trakt: 555 } },
@@ -1160,10 +1135,7 @@ describe('FlixPatrol', () => {
 
       const result = await flixpatrol.getMostWatched('Movies', config, mockTrakt as never);
 
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('-from-france'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('-from-france'));
     });
 
     it('should include premiere in URL when specified', async () => {
@@ -1195,9 +1167,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Movie', year: 2024, ids: { trakt: 666 } },
@@ -1214,10 +1186,7 @@ describe('FlixPatrol', () => {
 
       const result = await flixpatrol.getMostWatched('Movies', config, mockTrakt as never);
 
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('-2023'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('-2023'));
     });
 
     it('should include orderByViews in URL when specified', async () => {
@@ -1249,9 +1218,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Movie', year: 2024, ids: { trakt: 777 } },
@@ -1268,10 +1237,7 @@ describe('FlixPatrol', () => {
 
       const result = await flixpatrol.getMostWatched('Movies', config, mockTrakt as never);
 
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/by-views'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/by-views'));
     });
 
     it('should filter Netflix originals when original is true', async () => {
@@ -1311,9 +1277,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostWatchedHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostWatchedHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Original Movie', year: 2024, ids: { trakt: 888 } },
@@ -1372,16 +1338,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'The Matrix', year: 1999, ids: { trakt: 999 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'movies',
@@ -1417,16 +1383,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Unknown Movie', year: 0, ids: { trakt: 1000 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'movies',
@@ -1466,14 +1432,14 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue(null);
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'movies',
@@ -1500,12 +1466,12 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValueOnce({ status: 404, data: null });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'movies',
@@ -1544,16 +1510,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Breaking Bad', year: 2008, ids: { trakt: 1388 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'shows',
@@ -1589,16 +1555,16 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: popularHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: popularHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Fallback Title', year: 2024, ids: { trakt: 2000 } },
       });
 
       const config: FlixPatrolPopular = {
-        platform: 'imdb',
+        platform: 'wikipedia',
         privacy: 'private',
         limit: 1,
         type: 'movies',
@@ -1620,7 +1586,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should throw FlixPatrolError when page fetch fails', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolMostHours = {
         enabled: true,
@@ -1680,9 +1646,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostHoursTotalHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostHoursTotalHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Test Movie', year: 2024, ids: { trakt: 123 } },
@@ -1700,10 +1666,7 @@ describe('FlixPatrol', () => {
       const result = await flixpatrol.getMostHours('Movies', config, mockTrakt as never);
 
       expect(Array.isArray(result)).toBe(true);
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/streaming-services/most-hours-total/netflix/'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/streaming-services/most-hours-total/netflix/'));
     });
 
     it('should parse most hours total TV shows from toc-tv-shows section', async () => {
@@ -1751,9 +1714,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostHoursTotalHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostHoursTotalHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         show: { title: 'Test Show', year: 2024, ids: { trakt: 456 } },
@@ -1804,9 +1767,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostHoursTotalHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostHoursTotalHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'Movie', year: 2024, ids: { trakt: 100 } },
@@ -1847,8 +1810,8 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: mostHoursTotalHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: mostHoursTotalHtml }));
 
       const config: FlixPatrolMostHours = {
         enabled: true,
@@ -1865,7 +1828,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should use correct URL for first-week period', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolMostHours = {
         enabled: true,
@@ -1881,7 +1844,7 @@ describe('FlixPatrol', () => {
     });
 
     it('should use correct URL for first-month period', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ status: 404, data: null });
+      mockFetch.mockResolvedValue(mockHtmlResponse({ status: 404, data: null }));
 
       const config: FlixPatrolMostHours = {
         enabled: true,
@@ -1929,9 +1892,9 @@ describe('FlixPatrol', () => {
         </html>
       `;
 
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ status: 200, data: firstWeekHtml })
-        .mockResolvedValue({ status: 200, data: detailHtml });
+      mockFetch
+        .mockResolvedValueOnce(mockHtmlResponse({ status: 200, data: firstWeekHtml }))
+        .mockResolvedValue(mockHtmlResponse({ status: 200, data: detailHtml }));
 
       mockGetFirstItemByQuery.mockResolvedValue({
         movie: { title: 'English Movie', year: 2024, ids: { trakt: 789 } },
@@ -1949,10 +1912,7 @@ describe('FlixPatrol', () => {
       const result = await flixpatrol.getMostHours('Movies', config, mockTrakt as never);
 
       expect(Array.isArray(result)).toBe(true);
-      expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/streaming-services/most-hours-first-week/netflix/'),
-        expect.any(Object)
-      );
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/streaming-services/most-hours-first-week/netflix/'));
     });
   });
 });


### PR DESCRIPTION
## Description

FlixPatrol pages started returning `HTTP 403` with `cf-mitigated: challenge` for any request made from this scraper. The browser-style `User-Agent` we were sending via axios was not enough — Cloudflare's Bot Management fingerprints the TLS stack too (JA3/JA4), and Node.js + axios produces a signature that no real Chrome ever emits.

This PR swaps the HTTP client from `axios` (+ `axios-retry`) to [`impit`](https://github.com/apify/impit), an `napi-rs` binding over Rust's `reqwest` that impersonates a real Chrome's TLS + HTTP/2 fingerprint. With `browser: 'chrome'`, every protected FlixPatrol URL we hit (Top10, Popular, Most-Watched, Most-Hours) now returns 200 again.

Retries are reimplemented locally (3 attempts, exponential backoff on 408/429/5xx and network errors). The deprecated `FlixPatrolOptions.agent` option was removed since `impit` manages the User-Agent internally.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->