### PR TITLE
Bump brace-expansion to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,9 +2482,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Description

Minor patch bump of the `brace-expansion` transitive dependency (5.0.5 → 5.0.6) picked up by `npm ci` during local development. No vulnerabilities are reported by `npm audit`; this is just keeping the lockfile aligned with the latest patch release.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues