### PR TITLE
Make impit native-binding requires statically resolvable by pkg

### DIFF
--- a/scripts/patch-ncc-bundle.sh
+++ b/scripts/patch-ncc-bundle.sh
@@ -27,3 +27,10 @@ cp node_modules/mdn-data/css/at-rules.json build/tmp/node_modules/mdn-data/css/
 cp node_modules/mdn-data/css/properties.json build/tmp/node_modules/mdn-data/css/
 cp node_modules/mdn-data/css/syntaxes.json build/tmp/node_modules/mdn-data/css/
 cp node_modules/mdn-data/package.json build/tmp/node_modules/mdn-data/
+
+# Rewrite impit native-binding requires so pkg can statically detect them.
+# ncc emits `require(__nccwpck_require__.ab + "impit-node.X.node")` which pkg's
+# static analyzer cannot resolve, so the .node files are never extracted at runtime.
+# Replacing the dynamic concat with a string literal lets pkg detect the native module
+# and trigger its automatic extract-to-tmpdir flow.
+sed -i -E 's|require\(__nccwpck_require__\.ab \+ "(impit-node\.[a-zA-Z0-9_.-]+\.node)"\)|require("./\1")|g' "$BUNDLE"


### PR DESCRIPTION
## Description

After the previous PR shipped, the cross-platform binaries produced by `pkg` (and the Docker images built from them) still crashed at startup with `impit couldn't load native bindings`.

Root cause: `ncc` emits the native-binding require as

```js
require(__nccwpck_require__.ab + "impit-node.linux-x64-gnu.node")
```

`pkg` analyses requires statically (`pkg` log: `Cannot resolve '__nccwpck_require__.ab + "impit-node.linux-x64-gnu.node"'`). Because the path is a runtime concatenation, `pkg` never tags the `.node` file as a native module — so even though the file is shipped in the snapshot via `pkg.assets`, the runtime extract-to-tmpdir flow that `pkg` needs for `.node` files is never wired up, and `require()` fails inside the snapshot.

The fix patches the ncc bundle to rewrite every impit native-binding require into a string-literal form, e.g.

```js
require("./impit-node.linux-x64-gnu.node")
```

That literal is statically detectable by `pkg`, which then bundles the binding correctly and extracts it at runtime. Verified locally by running the produced `bin/flixpatrol-top10-linux-amd64` inside a fresh `debian:bookworm-slim` container (i.e. with no `.node` files present on disk) — the binary now starts and reaches the configuration step instead of failing in the native loader.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (\`npm run lint\`)
- [x] Tests pass (\`npm test\`)

## Related Issues