### PR TITLE
Provision a home directory for the flixpatrol Docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,13 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 
-# Create non-root user
+# Create non-root user with a real home directory. pkg's native-module extractor
+# (used by `impit`) writes `.node` files under $HOME at runtime, so without an
+# existing home directory the binary aborts with "impit couldn't load native bindings".
 RUN groupadd -g 1000 flixpatrol && \
-    useradd -u 1000 -g flixpatrol -s /bin/sh -M flixpatrol && \
+    useradd -u 1000 -g flixpatrol -s /bin/sh -m -d /home/flixpatrol flixpatrol && \
     mkdir -p /app/config && \
-    chown -R flixpatrol:flixpatrol /app
+    chown -R flixpatrol:flixpatrol /app /home/flixpatrol
 
 # Copy binary based on architecture
 ARG TARGETARCH


### PR DESCRIPTION
## Description

After moving the HTTP client to `impit`, running the published Docker image (`ghcr.io/navino16/flixpatrol-top10-on-trakt:latest`) crashed at startup with:

```
Error: impit couldn't load native bindings.
  cause: Error: Cannot find native binding. npm has a bug related to optional dependencies (...)
```

The same binary works fine on a bare `debian:bookworm-slim` container and even works inside our image when run as `root` or with `HOME=/tmp`. Root cause: pkg's native-module loader (which is what impit ultimately relies on once embedded in the `pkg` binary) writes the extracted `.node` files under `$HOME` on first run. Our Dockerfile created the `flixpatrol` user with `useradd -M`, so `$HOME=/home/flixpatrol` was set in the environment but the directory itself never existed — extraction silently failed and impit reported its generic "cannot load native bindings" error.

Switching to `useradd -m -d /home/flixpatrol` (and `chown`-ing it) makes pkg's extraction succeed, and the container starts and processes lists again.

Verified locally by rebuilding the image (`docker build -t fp-test --build-arg TARGETARCH=amd64 .`) and running it — startup now proceeds past the native loader.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (\`npm run lint\`)
- [x] Tests pass (\`npm test\`)

## Related Issues