### PR TITLE
Add startup banner logging version, runtime info, and config recap

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,15 @@ import type {
 import { GetAndValidateConfigs } from './Utils/GetAndValidateConfigs';
 import { TraktAPI } from './Trakt';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { version, name } = require('../package.json') as { version: string; name: string };
+
+logger.info('========================================');
+logger.info(`${name} v${version}`);
+logger.info(`Node.js ${process.version} on ${process.platform} (${process.arch})`);
+logger.info(`Log level: ${process.env.LOG_LEVEL || 'info'}`);
+logger.info('========================================');
+
 const dryRun = process.env.DRY_RUN === 'true';
 
 if (dryRun) {
@@ -41,6 +50,8 @@ try {
   logger.error(`${(err as Error).name}: ${(err as Error).message}`);
   process.exit(1);
 }
+
+logger.debug(`Config loaded: ${flixPatrolTop10.length} Top10, ${flixPatrolPopulars.length} Popular, ${flixPatrolMostWatched.filter((m) => m.enabled).length} MostWatched, ${flixPatrolMostHours.filter((m) => m.enabled).length} MostHours, cache ${cacheOptions.enabled ? 'enabled' : 'disabled'}`);
 
 logger.silly(`cacheOptions: ${JSON.stringify(cacheOptions)}`);
 logger.silly(`traktOptions: ${JSON.stringify({...traktOptions, clientId: 'REDACTED', clientSecret: 'REDACTED'})}`);


### PR DESCRIPTION
## Description

Logs application startup info so version and runtime context are visible in logs (useful for debugging, support, and confirming which build is running).

**INFO at startup** (before any other work):
```
========================================
flixpatrol-top10 v2.14.3
Node.js v24.13.1 on linux (x64)
Log level: info
========================================
```

**DEBUG after config load**: recap of configured lists (counts per type) and cache state.

## Type of change
- [x] New feature

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
<!-- N/A -->