### PR TITLE
Validate LOG_LEVEL and guard package.json read with fallbacks

### DIFF
--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -4,6 +4,10 @@ import {
 
 const myFormat = format.printf((info) => `[${info.timestamp}][${info.level}] ${info.message}`);
 
+const VALID_LOG_LEVELS = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
+const requestedLevel = process.env.LOG_LEVEL;
+const level = requestedLevel && VALID_LOG_LEVELS.includes(requestedLevel) ? requestedLevel : 'info';
+
 export const logger: Logger = createLogger({
   format: format.combine(
     format.colorize(),
@@ -12,8 +16,12 @@ export const logger: Logger = createLogger({
     format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
     myFormat,
   ),
-  level: process.env.LOG_LEVEL || 'info',
+  level,
   transports: [
     new transports.Console(),
   ],
 });
+
+if (requestedLevel && !VALID_LOG_LEVELS.includes(requestedLevel)) {
+  logger.warn(`Invalid LOG_LEVEL "${requestedLevel}", falling back to "info". Valid: ${VALID_LOG_LEVELS.join(', ')}`);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,8 +11,16 @@ import type {
 import { GetAndValidateConfigs } from './Utils/GetAndValidateConfigs';
 import { TraktAPI } from './Trakt';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { version, name } = require('../package.json') as { version: string; name: string };
+let version = 'unknown';
+let name = 'flixpatrol-top10';
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pkg = require('../package.json') as { version?: string; name?: string };
+  if (pkg.version) version = pkg.version;
+  if (pkg.name) name = pkg.name;
+} catch (err) {
+  logger.warn(`Could not read package.json: ${(err as Error).message}`);
+}
 
 logger.info('========================================');
 logger.info(`${name} v${version}`);


### PR DESCRIPTION
## Description

Hardening for the startup logging path — addresses 3 failure modes surfaced by the code review of #484/#494:

**`LOG_LEVEL` validation (`Logger.ts`)**
An invalid value (e.g. `LOG_LEVEL=DEBUG` uppercase, or a typo like `verbos`) used to silently produce zero log output because Winston compares levels by string equality. The whitelist `[error, warn, info, http, verbose, debug, silly]` is now enforced; invalid values fall back to `info` and emit an explicit warning.

**`package.json` read guarded (`app.ts`)**
The top-level `require('../package.json')` previously crashed with `MODULE_NOT_FOUND` before any logger output if the file was missing (e.g. broken pkg bundle, refactored build layout). It now runs inside try/catch with a warn + fallback so the app continues with `flixpatrol-top10 vunknown`.

**Missing `name`/`version` fields**
The type assertion `as { version: string; name: string }` was lying — partial/corrupt manifest would print literal `undefined v2.14.3`. Now defensive defaults are applied (`unknown` / `flixpatrol-top10`).

## Tested scenarios

| Scenario | Before | After |
|---|---|---|
| `LOG_LEVEL=DEBUG` | 0 lines logged (silent) | warn + fallback `info`, app continues |
| `package.json` absent | `MODULE_NOT_FOUND` crash | warn + `flixpatrol-top10 vunknown`, app continues |
| `name`/`version` removed | `undefined v2.14.3` | `flixpatrol-top10 vunknown` |

## Type of change
- [x] Bug fix

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
Follow-up to #484, #494