### PR TITLE
Add LIST_NAME_PREFIX env var to prefix list names in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Edit `./config/default.json`, then schedule periodic runs with cron.
 
 ### Environment Variables
 
-| Name      | Description                              | Values                          | Default |
-|-----------|------------------------------------------|---------------------------------|---------|
-| LOG_LEVEL | How verbose the log will be              | error, warn, info, debug, silly | info    |
-| DRY_RUN   | Run without making changes to Trakt      | true, false                     | false   |
+| Name             | Description                                                  | Values                          | Default |
+|------------------|--------------------------------------------------------------|---------------------------------|---------|
+| LOG_LEVEL        | How verbose the log will be                                  | error, warn, info, debug, silly | info    |
+| DRY_RUN          | Run without making changes to Trakt                          | true, false                     | false   |
+| LIST_NAME_PREFIX | String prepended to every list name (useful for dev/testing) | Any string, e.g. `[TEST]`       | (none)  |
 
 #### Dry-Run Mode
 
@@ -111,6 +112,20 @@ In dry-run mode:
 - Trakt search for ID conversion runs normally
 - OAuth authentication runs normally
 - List creation, item addition/removal, and updates are **logged but not executed**
+
+#### List Name Prefix
+
+Prepend a fixed string to every list name. Useful when running the tool against your real Trakt account during development or testing — the prefixed lists stay separate from your real lists and can be deleted in bulk afterwards.
+
+```bash
+# Linux/macOS — produces lists like "[TEST]netflix-world-top10-without-fallback"
+LIST_NAME_PREFIX='[TEST]' ./flixpatrol-top10-linux-x64
+
+# Docker
+docker run --rm -e LIST_NAME_PREFIX='[TEST]' -v "/path/to/config:/app/config" ghcr.io/navino16/flixpatrol-top10-on-trakt:latest
+```
+
+The prefix is applied verbatim, **after** the normalization step (so brackets, spaces, and special characters in the prefix are preserved as-is). When active, a warning is emitted at startup so you don't forget it is set.
 
 ### Configuration File
 

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -8,15 +8,15 @@ export class Utils {
 
   public static getListName(
     config: { name?: string; normalizeName?: boolean },
-    defaultName: string
+    defaultName: string,
+    prefix?: string,
   ): string {
-    if (config.name && config.normalizeName === false) {
-      return config.name;
-    }
-    if (config.name) {
-      return config.name.toLowerCase().replace(/\s+/g, '-');
-    }
-    return defaultName;
+    const base = (() => {
+      if (config.name && config.normalizeName === false) return config.name;
+      if (config.name) return config.name.toLowerCase().replace(/\s+/g, '-');
+      return defaultName;
+    })();
+    return prefix ? `${prefix}${base}` : base;
   }
 
   public static ensureConfigExist() {

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,12 +20,17 @@ logger.info(`Log level: ${logger.level}`);
 logger.info('========================================');
 
 const dryRun = process.env.DRY_RUN === 'true';
+const listNamePrefix = process.env.LIST_NAME_PREFIX || '';
 
 if (dryRun) {
   logger.info('========================================');
   logger.info('DRY-RUN MODE ENABLED');
   logger.info('No changes will be made to Trakt lists.');
   logger.info('========================================');
+}
+
+if (listNamePrefix) {
+  logger.warn(`LIST_NAME_PREFIX "${listNamePrefix}" is active — list names will be prefixed`);
 }
 
 Utils.ensureConfigExist();
@@ -77,7 +82,7 @@ trakt.connect().then(async () => {
   for (const top10 of flixPatrolTop10) {
     currentList++;
     const defaultName = `${top10.platform}-${top10.location}-top10-${top10.fallback === false ? 'without-fallback' : `with-${top10.fallback}-fallback`}`;
-    const baseListName = Utils.getListName(top10, defaultName);
+    const baseListName = Utils.getListName(top10, defaultName, listNamePrefix);
     logger.info('==============================');
     logger.info(`[${currentList}/${totalLists}] Processing "${baseListName}"`);
 
@@ -108,7 +113,7 @@ trakt.connect().then(async () => {
 
   for (const popular of flixPatrolPopulars) {
     currentList++;
-    const listName = Utils.getListName(popular, `${popular.platform}-popular`);
+    const listName = Utils.getListName(popular, `${popular.platform}-popular`, listNamePrefix);
     logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
 
     if (popular.type === 'movies' || popular.type === 'both') {
@@ -137,7 +142,7 @@ trakt.connect().then(async () => {
       defaultName = mostWatched.original !== undefined ? `${defaultName}-original` : defaultName;
       defaultName = mostWatched.premiere !== undefined ? `${defaultName}-${mostWatched.premiere}-premiere` : defaultName;
       defaultName = mostWatched.country !== undefined ? `${defaultName}-from-${mostWatched.country}` : defaultName;
-      const listName = Utils.getListName(mostWatched, defaultName);
+      const listName = Utils.getListName(mostWatched, defaultName, listNamePrefix);
       logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
 
       if (mostWatched.type === 'movies' || mostWatched.type === 'both') {
@@ -167,7 +172,7 @@ trakt.connect().then(async () => {
       if (mostHours.language !== 'all') {
         defaultName += `-${mostHours.language}`;
       }
-      const listName = Utils.getListName(mostHours, defaultName);
+      const listName = Utils.getListName(mostHours, defaultName, listNamePrefix);
       logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
 
       if (mostHours.type === 'movies' || mostHours.type === 'both') {

--- a/tests/Utils/Utils.test.ts
+++ b/tests/Utils/Utils.test.ts
@@ -109,6 +109,33 @@ describe('Utils', () => {
       const result = Utils.getListName(config, 'default-name');
       expect(result).toBe('-my-list-');
     });
+
+    it('should prepend prefix to the default name when no custom name is set', () => {
+      const result = Utils.getListName({}, 'netflix-top10', '[TEST]');
+      expect(result).toBe('[TEST]netflix-top10');
+    });
+
+    it('should prepend prefix after normalization', () => {
+      const config = { name: 'My Custom List' };
+      const result = Utils.getListName(config, 'default-name', '[TEST]');
+      expect(result).toBe('[TEST]my-custom-list');
+    });
+
+    it('should prepend prefix to a non-normalized custom name', () => {
+      const config = { name: 'My Custom List', normalizeName: false };
+      const result = Utils.getListName(config, 'default-name', '[TEST]');
+      expect(result).toBe('[TEST]My Custom List');
+    });
+
+    it('should not add any prefix when the prefix argument is undefined', () => {
+      const result = Utils.getListName({}, 'default-name');
+      expect(result).toBe('default-name');
+    });
+
+    it('should not add any prefix when the prefix argument is empty string', () => {
+      const result = Utils.getListName({}, 'default-name', '');
+      expect(result).toBe('default-name');
+    });
   });
 
   describe('ensureConfigExist', () => {


### PR DESCRIPTION
## Description

New `LIST_NAME_PREFIX` environment variable that prepends a fixed string to every Trakt list name. Designed for the workflow of running the tool against a real Trakt account during development or testing without polluting personal lists — set the prefix, run, then bulk-delete the prefixed lists when done.

**Behavior**
- Empty/undefined → no change to current behavior
- Set → prefix prepended verbatim **after** normalization, so `[TEST]netflix-top10` stays readable in Trakt regardless of `normalizeName` setting
- A `warn`-level log line is emitted at startup when the prefix is active, so it can't silently leak into prod runs

**API**
- `Utils.getListName(config, defaultName, prefix?: string)` — explicit third parameter, function stays pure (no env read inside)
- `app.ts` reads `process.env.LIST_NAME_PREFIX` once at boot and passes it to the 4 call sites (Top10, Popular, MostWatched, MostHours)

**Tests** — 5 new cases in `Utils.test.ts`:
- prefix + default name
- prefix + normalized custom name
- prefix + non-normalized custom name
- undefined prefix (no change)
- empty-string prefix (no change)

148 tests pass total.

**Docs**
- New row in the Environment Variables table in README.md
- New "List Name Prefix" subsection with Linux/macOS + Docker usage examples

## Type of change
- [x] New feature

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Documentation updated

## Related Issues
<!-- N/A -->