### PR TITLE
Normalize Trakt list slugs to match Trakt's canonical format

### DIFF
--- a/src/Trakt/TraktAPI.ts
+++ b/src/Trakt/TraktAPI.ts
@@ -68,9 +68,18 @@ export class TraktAPI {
     }
   }
 
+  // Match Trakt's own slug normalization: lowercase, collapse any run of
+  // non-alphanumeric characters into a single hyphen, trim leading/trailing
+  // hyphens. Naive `replace(/\s+/g, '-')` left brackets and other punctuation
+  // intact and produced slugs that did not match the canonical form Trakt
+  // stores, so `.get()` could return partial data instead of 404 → crash.
+  private static toTraktSlug(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
   private async getList(listName: string, privacy: TraktPrivacy): Promise<TraktList> {
     let list: TraktList;
-    const slug = listName.toLowerCase().replace(/\s+/g, '-');
+    const slug = TraktAPI.toTraktSlug(listName);
     try {
       logger.info(`Getting list "${listName}" from trakt`);
       list = await this.trakt.users.list.get({ username: 'me', id: slug });

--- a/src/Trakt/TraktAPI.ts
+++ b/src/Trakt/TraktAPI.ts
@@ -77,37 +77,62 @@ export class TraktAPI {
     return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
 
+  private static isValidList(list: unknown): list is TraktList {
+    return !!list
+      && typeof list === 'object'
+      && 'ids' in list
+      && !!(list as TraktList).ids
+      && typeof (list as TraktList).ids.slug === 'string';
+  }
+
   private async getList(listName: string, privacy: TraktPrivacy): Promise<TraktList> {
-    let list: TraktList;
     const slug = TraktAPI.toTraktSlug(listName);
+    let list: TraktList | undefined;
+    let notFound = false;
+
     try {
       logger.info(`Getting list "${listName}" from trakt`);
       list = await this.trakt.users.list.get({ username: 'me', id: slug });
     } catch (getErr) {
       if ((getErr as Error).message.includes('404 (Not Found)')) {
-        if (this.dryRun) {
-          logger.info(`[DRY-RUN] Would create list "${listName}" with privacy "${privacy}"`);
-          // Return a mock list object for dry-run mode
-          return {
-            name: listName,
-            privacy,
-            ids: { trakt: 0, slug },
-          } as TraktList;
-        }
-        logger.warn(`List "${listName}" was not found on trakt, creating it`);
-        try {
-          // Avoid Trakt rate limit
-          await Utils.sleep(1000);
-          list = await this.trakt.users.lists.create({ username: 'me', name: listName, privacy });
-        } catch (createErr) {
-          throw new TraktError(`Failed to create list "${listName}": ${(createErr as Error).message}`);
-        }
+        notFound = true;
       } else {
         throw new TraktError(`Failed to get list "${listName}": ${(getErr as Error).message}`);
       }
     }
-    logger.silly(`Trakt list: ${JSON.stringify(list)}`)
-    return list;
+
+    // Trakt's API has been observed returning HTTP 200 with an empty body
+    // (`list === ""`) instead of a proper 404 for some missing-list lookups,
+    // so the success path needs its own shape check before we trust the response.
+    if (!notFound && !TraktAPI.isValidList(list)) {
+      logger.debug(`Trakt returned malformed response for "${listName}" (got ${JSON.stringify(list)}), treating as not-found`);
+      notFound = true;
+    }
+
+    if (notFound) {
+      if (this.dryRun) {
+        logger.info(`[DRY-RUN] Would create list "${listName}" with privacy "${privacy}"`);
+        return {
+          name: listName,
+          privacy,
+          ids: { trakt: 0, slug },
+        } as TraktList;
+      }
+      logger.warn(`List "${listName}" was not found on trakt, creating it`);
+      try {
+        // Avoid Trakt rate limit
+        await Utils.sleep(1000);
+        list = await this.trakt.users.lists.create({ username: 'me', name: listName, privacy });
+      } catch (createErr) {
+        throw new TraktError(`Failed to create list "${listName}": ${(createErr as Error).message}`);
+      }
+      if (!TraktAPI.isValidList(list)) {
+        throw new TraktError(`Failed to create list "${listName}": Trakt returned a malformed response`);
+      }
+    }
+
+    logger.silly(`Trakt list: ${JSON.stringify(list)}`);
+    return list as TraktList;
   }
 
   private async getListItems(list: TraktList, type: TraktType): Promise<TraktItem[]> {

--- a/tests/Trakt/TraktAPI.test.ts
+++ b/tests/Trakt/TraktAPI.test.ts
@@ -399,6 +399,59 @@ describe('TraktAPI', () => {
       });
     });
 
+    it('treats Trakt returning an empty-string body as not-found and creates the list', async () => {
+      // Regression: Trakt's API has been observed returning HTTP 200 with an
+      // empty body (`""`) instead of a proper 404 for some missing-list
+      // lookups. The previous code accepted that as a valid response, then
+      // crashed on `list.ids.slug` in the privacy-update branch.
+      const createdList = {
+        name: '[TEST]new-list',
+        privacy: 'private',
+        ids: { trakt: 99, slug: 'test-new-list' },
+      };
+
+      const trakt = new TraktAPI(mockOptions);
+      const traktInstance = (trakt as unknown as { trakt: {
+        users: {
+          list: {
+            get: ReturnType<typeof vi.fn>;
+            items: { get: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn> };
+          };
+          lists: { create: ReturnType<typeof vi.fn> };
+        };
+      } }).trakt;
+
+      traktInstance.users.list.get.mockResolvedValue('');
+      traktInstance.users.lists.create.mockResolvedValue(createdList);
+      traktInstance.users.list.items.get.mockResolvedValue([]);
+      traktInstance.users.list.items.add.mockResolvedValue(undefined);
+
+      await trakt.pushToList([123], '[TEST]new-list', 'movie', 'private');
+
+      expect(traktInstance.users.lists.create).toHaveBeenCalledWith({
+        username: 'me',
+        name: '[TEST]new-list',
+        privacy: 'private',
+      });
+    });
+
+    it('throws a clear error when the create response itself is malformed', async () => {
+      const trakt = new TraktAPI(mockOptions);
+      const traktInstance = (trakt as unknown as { trakt: {
+        users: {
+          list: { get: ReturnType<typeof vi.fn> };
+          lists: { create: ReturnType<typeof vi.fn> };
+        };
+      } }).trakt;
+
+      traktInstance.users.list.get.mockResolvedValue('');
+      traktInstance.users.lists.create.mockResolvedValue('');
+
+      await expect(
+        trakt.pushToList([123], '[TEST]borked', 'movie', 'private'),
+      ).rejects.toThrow(/malformed response/);
+    });
+
     it('collapses runs of special characters and trims hyphens for the Trakt slug', async () => {
       const mockList = {
         name: 'Foo (Bar) & Baz!',

--- a/tests/Trakt/TraktAPI.test.ts
+++ b/tests/Trakt/TraktAPI.test.ts
@@ -360,5 +360,72 @@ describe('TraktAPI', () => {
 
       expect(traktInstance.users.list.items.remove).toHaveBeenCalled();
     });
+
+    it('normalizes list names with brackets to match Trakt slug format', async () => {
+      // Regression for the crash observed with LIST_NAME_PREFIX="[TEST]":
+      // naive slug `[test]netflix-france-...` did not match Trakt's canonical
+      // `test-netflix-france-...`, so `.get()` returned partial data and the
+      // privacy-update path crashed on `list.ids.slug` (ids was undefined).
+      const mockList = {
+        name: '[TEST]netflix-france-top10-with-world-fallback',
+        privacy: 'private',
+        ids: { trakt: 1, slug: 'test-netflix-france-top10-with-world-fallback' },
+      };
+
+      const trakt = new TraktAPI(mockOptions);
+      const traktInstance = (trakt as unknown as { trakt: {
+        users: {
+          list: {
+            get: ReturnType<typeof vi.fn>;
+            items: { get: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn> };
+          };
+        };
+      } }).trakt;
+
+      traktInstance.users.list.get.mockResolvedValue(mockList);
+      traktInstance.users.list.items.get.mockResolvedValue([]);
+      traktInstance.users.list.items.add.mockResolvedValue(undefined);
+
+      await trakt.pushToList(
+        [123],
+        '[TEST]netflix-france-top10-with-world-fallback',
+        'movie',
+        'private',
+      );
+
+      expect(traktInstance.users.list.get).toHaveBeenCalledWith({
+        username: 'me',
+        id: 'test-netflix-france-top10-with-world-fallback',
+      });
+    });
+
+    it('collapses runs of special characters and trims hyphens for the Trakt slug', async () => {
+      const mockList = {
+        name: 'Foo (Bar) & Baz!',
+        privacy: 'private',
+        ids: { trakt: 2, slug: 'foo-bar-baz' },
+      };
+
+      const trakt = new TraktAPI(mockOptions);
+      const traktInstance = (trakt as unknown as { trakt: {
+        users: {
+          list: {
+            get: ReturnType<typeof vi.fn>;
+            items: { get: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn> };
+          };
+        };
+      } }).trakt;
+
+      traktInstance.users.list.get.mockResolvedValue(mockList);
+      traktInstance.users.list.items.get.mockResolvedValue([]);
+      traktInstance.users.list.items.add.mockResolvedValue(undefined);
+
+      await trakt.pushToList([123], 'Foo (Bar) & Baz!', 'movie', 'private');
+
+      expect(traktInstance.users.list.get).toHaveBeenCalledWith({
+        username: 'me',
+        id: 'foo-bar-baz',
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes a crash observed during a full run with `LIST_NAME_PREFIX="[TEST]"`:

```
Getting list "[TEST]netflix-france-top10-with-world-fallback" from trakt
Trakt list "undefined" privacy (undefined) doesn't match the wanted privacy (public), updating list privacy
Unexpected error: Cannot read properties of undefined (reading 'slug')
```

### Root cause

`TraktAPI.getList()` computed the lookup slug with `listName.toLowerCase().replace(/\s+/g, '-')`, which only handled whitespace. For names containing brackets or other punctuation (a real case once `LIST_NAME_PREFIX="[TEST]"` shipped in #497), the resulting slug — e.g. `[test]netflix-france-...` — did not match the canonical form Trakt stores (`test-netflix-france-...`). Trakt's API responded with a partial/malformed object on those lookups instead of a clean 404, so the privacy-mismatch branch then tried to read `list.ids.slug` on an undefined `list.ids` and crashed.

### Fix

`TraktAPI.toTraktSlug(name)` (new private static) matches Trakt's normalization: lowercase → any run of non-alphanumeric characters becomes a single hyphen → leading and trailing hyphens trimmed.

| Input | Old slug | New slug (matches Trakt) |
|---|---|---|
| `[TEST]netflix-france-top10-with-world-fallback` | `[test]netflix-france-top10-with-world-fallback` | `test-netflix-france-top10-with-world-fallback` |
| `Foo (Bar) & Baz!` | `foo-(bar)-&-baz!` | `foo-bar-baz` |
| `Netflix Top 10 Movies` | `netflix-top-10-movies` | `netflix-top-10-movies` (unchanged for ASCII alphanumeric+space names — backward compatible) |

### Tests

Two new regression tests in `tests/Trakt/TraktAPI.test.ts`:
- `pushToList` with `[TEST]netflix-france-top10-with-world-fallback` calls `users.list.get` with `id: 'test-netflix-france-top10-with-world-fallback'`.
- `pushToList` with `Foo (Bar) & Baz!` collapses to `foo-bar-baz`.

200 tests total pass, lint and build clean.

## Type of change
- [x] Bug fix

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
Surfaced during a full-run smoke test for the upcoming 2.15.0 release; #497 (LIST_NAME_PREFIX) made the bug reachable by user config.