### PR TITLE
Add empty Notifications stub to the default config and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,16 @@ If there is any configuration error, the tool will exit with information about t
     "enabled": true,
     "savePath": "./config/.cache",
     "ttl": 604800
+  },
+  "Notifications": {
+    "run_start": [],
+    "run_end": [],
+    "error": []
   }
 }
 ```
+
+The `Notifications` block is fully optional — leave the arrays empty (or omit the block entirely) to disable notifications. See [Notifications](#notifications) above for the supported destination types and a worked example.
 
 </details>
 

--- a/config/default.json
+++ b/config/default.json
@@ -72,5 +72,10 @@
     "enabled": true,
     "savePath": "./config/.cache",
     "ttl": 604800
+  },
+  "Notifications": {
+    "run_start": [],
+    "run_end": [],
+    "error": []
   }
 }

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -138,6 +138,11 @@ export class Utils {
           savePath: './config/.cache',
           ttl: 604800,
         },
+        Notifications: {
+          run_start: [],
+          run_end: [],
+          error: [],
+        },
       };
 
       fs.writeFileSync('./config/default.json', JSON.stringify(defaultConfig, null, 2) + '\n');


### PR DESCRIPTION
## Description

Surface the new `Notifications` block (added in #498) in the three places where users discover available config keys:

- **`config/default.json`** (committed example) — gains `"Notifications": { "run_start": [], "run_end": [], "error": [] }`.
- **`src/Utils/Utils.ts`** `ensureConfigExist()` (auto-generated default written when no config file is present) — same stub.
- **`README.md`** *Example configuration* block — same stub, plus a one-line note pointing readers to the existing `#### Notifications` subsection that documents the destination types and a worked example.

All three stubs are no-ops: each event array is empty, so `NotificationManager.dispatch()` immediately returns. The Zod schema (`NotificationsSchema`) accepts empty arrays, so no migration is needed for users who already have configs without the block — it remains entirely optional.

This is the follow-up to the notifications system landed in #498 — surfacing the block in the default config means users see it exists without having to read the README first.

## Type of change
- [x] Documentation

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Documentation updated

## Related Issues
Follow-up to #498