### PR TITLE
Trust top10 section heading for type instead of detail-page label

### DIFF
--- a/src/Flixpatrol/FlixPatrol.ts
+++ b/src/Flixpatrol/FlixPatrol.ts
@@ -327,12 +327,15 @@ export class FlixPatrol {
       return searchType === 'movie' ? looked.movie?.ids.trakt ?? null : looked.show?.ids.trakt ?? null;
     };
 
-    let id: TraktTVId = null;
-    if (type === 'Movies') {
-      if (flixType === 'Movie' || !flixType) id = await tryLookup('movie');
-    } else {
-      if (flixType === 'TV Show' || !flixType) id = await tryLookup('show');
-    }
+    // The caller already passed us the expected type (parseTop10Page targets a
+    // specific section heading). We previously tried to confirm against the
+    // detail page's flixType label, but FlixPatrol's markup drifted and that
+    // span now contains "Movie" on every detail page (see flixType log below),
+    // silently rejecting every legitimate TV-show match.
+    logger.silly(`Detected flixType="${flixType}" for ${result} (looking for ${type})`);
+    const id: TraktTVId = type === 'Movies'
+      ? await tryLookup('movie')
+      : await tryLookup('show');
 
     if (id && this.tvCache !== null && this.movieCache !== null) {
       if (type === 'Movies') await this.movieCache.set(result, id);


### PR DESCRIPTION
## Description

Fixes a bug where every Top10 list configured with `type: "both"` only synced movies and silently dropped all TV shows.

### Symptom

Full run with two Netflix/HBO Max France Top10 lists (`type: "both"`) :

```
[1/2] Processing "[TEST]netflix-france-top10-with-world-fallback"
... Found 10 Movies in //div[h3[text() = "TOP 10 Movies"]]/...
... Found 10 TV Shows in //div[h3[text() = "TOP 10 TV Shows"]]/...
... (10 show detail pages fetched)
Saving movies for "[TEST]netflix-france-top10-with-world-fallback"
List ... updated with 10 new movies
[2/2] Processing "[TEST]hbo-max-france-top10-with-world-fallback"   <-- no "Saving shows", no shows synced
```

Both top10 sections were parsed correctly, all 10 show detail pages were fetched — but the show array returned by `getTop10Sections` was empty.

### Root cause

`FlixPatrol.getTraktTVId` confirmed the type by re-parsing the detail page's "Movie / TV Show" label and bailed out when the label didn't match strict equality:

```ts
if (type === 'Movies') {
  if (flixType === 'Movie' || !flixType) id = await tryLookup('movie');
} else {
  if (flixType === 'TV Show' || !flixType) id = await tryLookup('show');
}
```

A `LOG_LEVEL=silly` run on the live site shows the detail page now exposes `flixType="Movie"` on **every** detail page — movies AND shows alike — so the `'TV Show'` branch was unreachable and every show search was skipped:

```
[silly] Detected flixType="Movie" for /title/house-of-the-dragon/ (looking for TV Shows)
[silly] Detected flixType="Movie" for /title/rick-and-morty/ (looking for TV Shows)
[silly] Detected flixType="Movie" for /title/avatar-the-last-airbender-2024/ (looking for TV Shows)
... 10 shows, all flixType="Movie", all skipped
```

FlixPatrol's detail markup has drifted; the type span the XPath targets is no longer reliable.

### Fix

`parseTop10Page` is already called with a specific section header (`"TOP 10 Movies"` vs `"TOP 10 TV Shows"`), so the calling context already encodes the type. The detail-page re-check was paranoid defence against cross-section contamination and is no longer pulling its weight — it has flipped from useful to actively harmful.

`getTraktTVId` now trusts the caller's `type` parameter and queries Trakt for `movie` or `show` directly. A silly-level log of the detected `flixType` is kept for future debugging when FlixPatrol's markup drifts again.

### Verified end-to-end

```
[21:54:18] Saving movies for "[TEST]netflix-france-top10-with-world-fallback"
[21:54:23] List [TEST]netflix-france-top10-with-world-fallback updated with 10 new movies
[21:54:23] Saving shows for "[TEST]netflix-france-top10-with-world-fallback"
[21:54:27] List [TEST]netflix-france-top10-with-world-fallback updated with 10 new shows
[21:54:36] Saving movies for "[TEST]hbo-max-france-top10-with-world-fallback"
[21:54:41] List [TEST]hbo-max-france-top10-with-world-fallback updated with 10 new movies
[21:54:41] Saving shows for "[TEST]hbo-max-france-top10-with-world-fallback"
[21:54:45] List [TEST]hbo-max-france-top10-with-world-fallback updated with 10 new shows
```

Both list types now sync as documented.

### Tests

Existing test suite (202) still passes. The two FlixPatrol fixtures that exercise detail-page parsing (`should extract title and year from detail page`, etc.) cover the movie path and continue to pass; the show path was the broken one and is now unblocked by removing the defensive check.

## Type of change
- [x] Bug fix

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)