### PR TITLE
chore: remove deprecated @types/config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/config": "^4.4.0",
         "@types/jsdom": "^28.0.3",
         "@types/node": "^26.1.0",
         "@vercel/ncc": "^0.44.1",
@@ -1550,17 +1549,6 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
-      }
-    },
-    "node_modules/@types/config": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/config/-/config-4.4.0.tgz",
-      "integrity": "sha512-+82/thz8il6uR6mWFuMTWyC+jSXE4PIZUPmAfKUDOuvNULq3BPLM+tSKsAe3eOIOMKx5azvg3Q3JljWV9yX7aw==",
-      "deprecated": "This is a stub types definition. config provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "config": "*"
       }
     },
     "node_modules/@types/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/config": "^4.4.0",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^26.1.0",
     "@vercel/ncc": "^0.44.1",


### PR DESCRIPTION
## Description
Remove the deprecated `@types/config` dev dependency. The `config` package (v4.4.2) ships its own type definitions (`types/lib/config.d.ts`), so the stub `@types/config` is redundant — its own deprecation notice states: "config provides its own type definitions, so you do not need this installed."

Surfaced by Renovate's Dependency Dashboard (no replacement package, just a removal).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)

## Related Issues
