### PR TITLE
chore: sync renovate config with main

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,21 +4,30 @@
     "config:recommended",
     ":dependencyDashboard"
   ],
-  "baseBranches": ["develop"],
+  "baseBranchPatterns": [
+    "develop"
+  ],
   "schedule": ["before 6am on monday"],
   "packageRules": [
     {
-      "description": "Group GitHub Actions minor and patch updates",
+      "description": "Group and auto-merge npm minor and patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "code-dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Group and auto-merge GitHub Actions minor and patch updates",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "ci-dependencies",
       "automerge": true
     },
     {
-      "description": "Group npm minor and patch updates",
-      "matchManagers": ["npm"],
+      "description": "Group and auto-merge Dockerfile base image minor and patch updates",
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "code-dependencies",
+      "groupName": "docker-dependencies",
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Description
Sync `.github/renovate.json` on `develop` with the version on `main` to remove drift and prevent a future `main` -> `develop` merge conflict.

Brings two changes already on `main`:
- `baseBranches` renamed to `baseBranchPatterns` (Renovate config migration)
- adds the Dockerfile base-image auto-merge rule

Renovate only reads config from the default branch (`main`), so this is hygiene only — no behaviour change.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Config validated (`renovate-config-validator`)

## Related Issues
