### PR TITLE
feat: add daemon mode with built-in cron scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   <a href="#configuration">Configuration</a> &bull;
   <a href="#supported-platforms">Supported Platforms</a> &bull;
   <a href="#scheduling">Scheduling</a> &bull;
+  <a href="#daemon-mode-built-in-scheduling">Daemon Mode</a> &bull;
   <a href="#troubleshooting">Troubleshooting</a> &bull;
   <a href="#development">Development</a>
 </p>
@@ -279,6 +280,19 @@ If there is any configuration error, the tool will exit with information about t
 </details>
 
 <details>
+<summary><strong>Schedule</strong> — Daemon mode / built-in scheduling configuration</summary>
+
+| Name       | Description                                                              | Mandatory | Values                                | Default |
+|------------|---------------------------------------------------------------------------|-----------|----------------------------------------|---------|
+| enabled    | Enable the built-in scheduler (daemon mode)?                             | No        | true, false                           | false   |
+| crons      | Cron expression(s) the app runs on, 5-field format (`min hour day month weekday`) | Yes, when `enabled: true` | Array of valid cron strings, e.g. `["0 6 * * *"]` | []      |
+| runOnStart | Also run immediately at startup, in addition to the schedule?            | No        | true, false                           | false   |
+
+The whole `Schedule` block is optional — omit it entirely (or leave `enabled: false`) to keep the classic one-shot behaviour: the app runs once and exits, exactly like today. See [Daemon Mode](#daemon-mode-built-in-scheduling) below for details.
+
+</details>
+
+<details>
 <summary><strong>Example configuration</strong></summary>
 
 ```json
@@ -377,11 +391,18 @@ If there is any configuration error, the tool will exit with information about t
     "run_start": [],
     "run_end": [],
     "error": []
+  },
+  "Schedule": {
+    "enabled": false,
+    "crons": ["0 6 * * *"],
+    "runOnStart": false
   }
 }
 ```
 
 The `Notifications` block is fully optional — leave the arrays empty (or omit the block entirely) to disable notifications. See [Notifications](#notifications) above for the supported destination types and a worked example.
+
+The `Schedule` block is fully optional and disabled by default — omit it (or leave `enabled: false`) to keep the classic one-shot behaviour. See [Daemon Mode](#daemon-mode-built-in-scheduling) below.
 
 </details>
 
@@ -440,6 +461,68 @@ For the complete list, see the source code: [Config.types.ts](https://github.com
 2. Create a new task
 3. Set the trigger (e.g., daily at 6 AM)
 4. Set the action to run the executable
+
+## Daemon Mode (built-in scheduling)
+
+Instead of relying on an external scheduler (cron, Task Scheduler, `docker run` on a timer), the app can run as a long-lived
+process with its own built-in scheduler. Add a `Schedule` block to `config/default.json` and set `enabled: true`:
+
+```json
+{
+  "Schedule": {
+    "enabled": true,
+    "crons": ["0 6 * * *"],
+    "runOnStart": false
+  }
+}
+```
+
+| Field        | Description                                                                 |
+|--------------|------------------------------------------------------------------------------|
+| `enabled`    | Turns daemon mode on. When `false` or omitted, the app runs once and exits — the current behaviour is completely unchanged. |
+| `crons`      | One or more cron expressions, standard 5-field format (`min hour day month weekday`), e.g. `"0 6 * * *"` for daily at 6 AM. Must contain at least one entry when `enabled` is `true`. |
+| `runOnStart` | When `true`, triggers an immediate run at startup, then continues to follow the configured schedule. |
+
+### Backward compatibility
+
+The `Schedule` block is entirely optional. If it is absent, or `enabled` is `false`, the app behaves exactly as before:
+it runs once and exits with the appropriate code. Your existing external cron job or `docker run` on a timer keeps
+working without any change.
+
+### Timezone
+
+The scheduler follows the system clock. There is no timezone field in the config — set the `TZ` environment variable
+(e.g. `TZ=Europe/Paris`) on the host or container so cron expressions are evaluated in the timezone you expect.
+
+### Behaviour while running
+
+- If a scheduled trigger fires while a run is still in progress, it is skipped (logged as a warning) rather than
+  queued or run concurrently.
+- A failed run is logged and sent through the [Notifications](#notifications) system (the `error` event), but it does
+  **not** stop the daemon — the scheduler keeps waiting for the next trigger.
+- On `SIGTERM` (e.g. `docker stop`) or `SIGINT` (Ctrl-C), the app performs a graceful shutdown: it stops accepting new
+  triggers and waits for the current run to finish its Trakt write before exiting, so lists are never left half-updated.
+
+### Docker Compose example
+
+Run the container as a long-lived daemon instead of a one-shot job:
+
+```yaml
+# docker-compose.yml
+services:
+  flixpatrol:
+    image: ghcr.io/navino16/flixpatrol-top10-on-trakt:latest
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Paris
+    volumes:
+      - ./config:/app/config
+```
+
+With `Schedule.enabled: true` in `config/default.json`, this container stays up, runs on the configured cron
+schedule(s), and survives restarts (`restart: unless-stopped`). This replaces the external-cron pattern shown above
+(`docker run` triggered by a host cron entry) — you no longer need a cron job on the host, since the schedule now
+lives inside the app itself.
 
 ## Troubleshooting
 

--- a/config/default.json
+++ b/config/default.json
@@ -77,5 +77,10 @@
     "run_start": [],
     "run_end": [],
     "error": []
+  },
+  "Schedule": {
+    "enabled": false,
+    "crons": ["0 6 * * *"],
+    "runOnStart": false
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "file-system-cache": "^2.4.7",
         "impit": "^0.14.1",
         "jsdom": "^29.1.1",
+        "node-cron": "^4.6.0",
         "trakt.tv": "^8.2.0",
         "winston": "^3.19.0",
         "zod": "^4.4.3"
@@ -4537,6 +4538,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "file-system-cache": "^2.4.7",
     "impit": "^0.14.1",
     "jsdom": "^29.1.1",
+    "node-cron": "^4.6.0",
     "trakt.tv": "^8.2.0",
     "winston": "^3.19.0",
     "zod": "^4.4.3"

--- a/src/Pipeline/index.ts
+++ b/src/Pipeline/index.ts
@@ -1,0 +1,1 @@
+export * from './runPipeline';

--- a/src/Pipeline/runPipeline.ts
+++ b/src/Pipeline/runPipeline.ts
@@ -1,0 +1,239 @@
+import { FlixPatrol } from '../Flixpatrol';
+import { TraktAPI } from '../Trakt';
+import { logger, Utils } from '../Utils';
+import type {
+  NotificationEvent, NotificationPayload, RunSummary,
+} from '../Notifications';
+import type {
+  CacheOptions, FlixPatrolMostWatched, FlixPatrolMostHours,
+  FlixPatrolPopular, FlixPatrolTop10, TraktAPIOptions,
+} from '../types';
+
+export interface RunPipelineDeps {
+  cacheOptions: CacheOptions;
+  traktOptions: TraktAPIOptions;
+  flixPatrolTop10: FlixPatrolTop10[];
+  flixPatrolPopulars: FlixPatrolPopular[];
+  flixPatrolMostWatched: FlixPatrolMostWatched[];
+  flixPatrolMostHours: FlixPatrolMostHours[];
+  dispatch: (event: NotificationEvent, payload: NotificationPayload) => Promise<void>;
+  dryRun: boolean;
+  listNamePrefix: string;
+  appName: string;
+  appVersion: string;
+  signal?: AbortSignal;
+}
+
+export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
+  const dryRunTag = deps.dryRun ? '[DRY-RUN] ' : '';
+
+  const enabledMostWatched = deps.flixPatrolMostWatched.filter((m) => m.enabled).length;
+  const enabledMostHours = deps.flixPatrolMostHours.filter((m) => m.enabled).length;
+
+  logger.debug(`Config loaded: ${deps.flixPatrolTop10.length} Top10, ${deps.flixPatrolPopulars.length} Popular, ${enabledMostWatched} MostWatched, ${enabledMostHours} MostHours, cache ${deps.cacheOptions.enabled ? 'enabled' : 'disabled'}`);
+
+  logger.silly(`cacheOptions: ${JSON.stringify(deps.cacheOptions)}`);
+  logger.silly(`traktOptions: ${JSON.stringify({...deps.traktOptions, clientId: 'REDACTED', clientSecret: 'REDACTED'})}`);
+  logger.silly(`flixPatrolTop10: ${JSON.stringify(deps.flixPatrolTop10)}`);
+  logger.silly(`flixPatrolPopulars: ${JSON.stringify(deps.flixPatrolPopulars)}`);
+  logger.silly(`flixPatrolMostWatched: ${JSON.stringify(deps.flixPatrolMostWatched)}`);
+  logger.silly(`flixPatrolMostHours: ${JSON.stringify(deps.flixPatrolMostHours)}`);
+
+  const flixpatrol = new FlixPatrol(deps.cacheOptions);
+  const trakt = new TraktAPI({ ...deps.traktOptions, dryRun: deps.dryRun });
+
+  const totalLists = deps.flixPatrolTop10.length
+    + deps.flixPatrolPopulars.length
+    + enabledMostWatched
+    + enabledMostHours;
+  let currentList = 0;
+  const runStartAt = Date.now();
+  const summary: RunSummary = {
+    listsProcessed: 0,
+    moviesAdded: 0,
+    showsAdded: 0,
+    durationMs: 0,
+  };
+
+  await trakt.connect();
+
+  // Fire-and-forget: do not block the pipeline on the notification round-trip.
+  // The dispatch is tracked by the caller so it gets flushed before any process.exit
+  // (even on a fast-failing run).
+  void deps.dispatch('run_start', {
+    title: `${dryRunTag}${deps.appName} v${deps.appVersion} run started`,
+    body: `Processing ${totalLists} lists`,
+    timestamp: new Date().toISOString(),
+  });
+
+  for (const top10 of deps.flixPatrolTop10) {
+    currentList++;
+    const defaultName = `${top10.platform}-${top10.location}-top10-${top10.fallback === false ? 'without-fallback' : `with-${top10.fallback}-fallback`}`;
+    const baseListName = Utils.getListName(top10, defaultName, deps.listNamePrefix);
+    logger.info('==============================');
+    logger.info(`[${currentList}/${totalLists}] Processing "${baseListName}"`);
+
+    const { movies, shows, rawCounts } = await flixpatrol.getTop10Sections(top10, trakt);
+
+    if (movies.length > 0) {
+      logger.info('==============================');
+      if (rawCounts.movies > movies.length) {
+        logger.warn(`Some movies from FlixPatrol could not be matched on Trakt (${rawCounts.movies} found, ${movies.length} matched)`);
+      }
+      logger.info(`Saving movies for "${baseListName}"`);
+      logger.debug(`${top10.platform} movies: ${movies}`);
+      if (deps.signal?.aborted) {
+        logger.info('System: Graceful stop requested — halting after current Trakt write');
+        return summary;
+      }
+      await trakt.pushToList(movies, baseListName, 'movie', top10.privacy);
+      logger.info(`List ${baseListName} updated with ${movies.length} new movies`);
+      summary.moviesAdded += movies.length;
+    }
+    if (shows.length > 0) {
+      logger.info('==============================');
+      if (rawCounts.shows > shows.length) {
+        logger.warn(`Some shows from FlixPatrol could not be matched on Trakt (${rawCounts.shows} found, ${shows.length} matched)`);
+      }
+      logger.info(`Saving shows for "${baseListName}"`);
+      logger.debug(`${top10.platform} shows: ${shows}`);
+      if (deps.signal?.aborted) {
+        logger.info('System: Graceful stop requested — halting after current Trakt write');
+        return summary;
+      }
+      await trakt.pushToList(shows, baseListName, 'show', top10.privacy);
+      logger.info(`List ${baseListName} updated with ${shows.length} new shows`);
+      summary.showsAdded += shows.length;
+    }
+    summary.listsProcessed++;
+  }
+
+
+  for (const popular of deps.flixPatrolPopulars) {
+    currentList++;
+    const listName = Utils.getListName(popular, `${popular.platform}-popular`, deps.listNamePrefix);
+    logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
+
+    if (popular.type === 'movies' || popular.type === 'both') {
+      logger.info('==============================');
+      logger.info(`Getting movies for "${listName}"`);
+      const popularMovies = await flixpatrol.getPopular('Movies', popular, trakt);
+      logger.debug(`${popular.platform} movies: ${popularMovies}`);
+      if (deps.signal?.aborted) {
+        logger.info('System: Graceful stop requested — halting after current Trakt write');
+        return summary;
+      }
+      await trakt.pushToList(popularMovies, listName, 'movie', popular.privacy);
+      logger.info(`List ${listName} updated with ${popularMovies.length} new movies`);
+      summary.moviesAdded += popularMovies.length;
+    }
+
+    if (popular.type === 'shows' || popular.type === 'both') {
+      logger.info('==============================');
+      logger.info(`Getting shows for "${listName}"`);
+      const popularShows = await flixpatrol.getPopular('TV Shows', popular, trakt);
+      logger.debug(`${popular.platform} shows: ${popularShows}`);
+      if (deps.signal?.aborted) {
+        logger.info('System: Graceful stop requested — halting after current Trakt write');
+        return summary;
+      }
+      await trakt.pushToList(popularShows, listName, 'show', popular.privacy);
+      logger.info(`List ${listName} updated with ${popularShows.length} new shows`);
+      summary.showsAdded += popularShows.length;
+    }
+    summary.listsProcessed++;
+  }
+
+  for (const mostWatched of deps.flixPatrolMostWatched) {
+    if (mostWatched.enabled) {
+      currentList++;
+      let defaultName = `most-watched-${mostWatched.year}-netflix`;
+      defaultName = mostWatched.original !== undefined ? `${defaultName}-original` : defaultName;
+      defaultName = mostWatched.premiere !== undefined ? `${defaultName}-${mostWatched.premiere}-premiere` : defaultName;
+      defaultName = mostWatched.country !== undefined ? `${defaultName}-from-${mostWatched.country}` : defaultName;
+      const listName = Utils.getListName(mostWatched, defaultName, deps.listNamePrefix);
+      logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
+
+      if (mostWatched.type === 'movies' || mostWatched.type === 'both') {
+        logger.info('==============================');
+        logger.info(`Getting movies for "${listName}"`);
+        const mostWatchedMovies = await flixpatrol.getMostWatched('Movies', mostWatched, trakt);
+        logger.debug(`most-watched movies: ${mostWatchedMovies}`);
+        if (deps.signal?.aborted) {
+          logger.info('System: Graceful stop requested — halting after current Trakt write');
+          return summary;
+        }
+        await trakt.pushToList(mostWatchedMovies, listName, 'movie', mostWatched.privacy);
+        logger.info(`List ${listName} updated with ${mostWatchedMovies.length} new movies`);
+        summary.moviesAdded += mostWatchedMovies.length;
+      }
+
+      if (mostWatched.type === 'shows' || mostWatched.type === 'both') {
+        logger.info('==============================');
+        logger.info(`Getting shows for "${listName}"`);
+        const mostWatchedShows = await flixpatrol.getMostWatched('TV Shows', mostWatched, trakt);
+        logger.debug(`most-watched shows: ${mostWatchedShows}`);
+        if (deps.signal?.aborted) {
+          logger.info('System: Graceful stop requested — halting after current Trakt write');
+          return summary;
+        }
+        await trakt.pushToList(mostWatchedShows, listName, 'show', mostWatched.privacy);
+        logger.info(`List ${listName} updated with ${mostWatchedShows.length} new shows`);
+        summary.showsAdded += mostWatchedShows.length;
+      }
+      summary.listsProcessed++;
+    }
+  }
+
+  for (const mostHours of deps.flixPatrolMostHours) {
+    if (mostHours.enabled) {
+      currentList++;
+      let defaultName = `netflix-most-hours-${mostHours.period}`;
+      if (mostHours.language !== 'all') {
+        defaultName += `-${mostHours.language}`;
+      }
+      const listName = Utils.getListName(mostHours, defaultName, deps.listNamePrefix);
+      logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
+
+      if (mostHours.type === 'movies' || mostHours.type === 'both') {
+        logger.info('==============================');
+        logger.info(`Getting movies for "${listName}"`);
+        const mostHoursMovies = await flixpatrol.getMostHours('Movies', mostHours, trakt);
+        logger.debug(`most-hours-${mostHours.period} movies: ${mostHoursMovies}`);
+        if (deps.signal?.aborted) {
+          logger.info('System: Graceful stop requested — halting after current Trakt write');
+          return summary;
+        }
+        await trakt.pushToList(mostHoursMovies, listName, 'movie', mostHours.privacy);
+        logger.info(`List ${listName} updated with ${mostHoursMovies.length} new movies`);
+        summary.moviesAdded += mostHoursMovies.length;
+      }
+
+      if (mostHours.type === 'shows' || mostHours.type === 'both') {
+        logger.info('==============================');
+        logger.info(`Getting shows for "${listName}"`);
+        const mostHoursShows = await flixpatrol.getMostHours('TV Shows', mostHours, trakt);
+        logger.debug(`most-hours-${mostHours.period} shows: ${mostHoursShows}`);
+        if (deps.signal?.aborted) {
+          logger.info('System: Graceful stop requested — halting after current Trakt write');
+          return summary;
+        }
+        await trakt.pushToList(mostHoursShows, listName, 'show', mostHours.privacy);
+        logger.info(`List ${listName} updated with ${mostHoursShows.length} new shows`);
+        summary.showsAdded += mostHoursShows.length;
+      }
+      summary.listsProcessed++;
+    }
+  }
+
+  summary.durationMs = Date.now() - runStartAt;
+  const movedVerb = deps.dryRun ? 'would be added' : 'added';
+  await deps.dispatch('run_end', {
+    title: `${dryRunTag}${deps.appName} run finished`,
+    body: `${dryRunTag}Processed ${summary.listsProcessed}/${totalLists} lists in ${Math.round(summary.durationMs / 1000)}s — ${summary.moviesAdded} movies / ${summary.showsAdded} shows ${movedVerb}`,
+    timestamp: new Date().toISOString(),
+    summary,
+  });
+
+  return summary;
+}

--- a/src/Pipeline/runPipeline.ts
+++ b/src/Pipeline/runPipeline.ts
@@ -27,6 +27,19 @@ export interface RunPipelineDeps {
 export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
   const dryRunTag = deps.dryRun ? '[DRY-RUN] ' : '';
 
+  const abortedBeforeWrite = async (): Promise<boolean> => {
+    if (!deps.signal?.aborted) {
+      return false;
+    }
+    logger.info('System: Graceful stop requested — halting after current Trakt write');
+    await deps.dispatch('error', {
+      title: `${dryRunTag}${deps.appName} run interrupted`,
+      body: 'The run was interrupted by a shutdown signal (SIGTERM/SIGINT)',
+      timestamp: new Date().toISOString(),
+    });
+    return true;
+  };
+
   const enabledMostWatched = deps.flixPatrolMostWatched.filter((m) => m.enabled).length;
   const enabledMostHours = deps.flixPatrolMostHours.filter((m) => m.enabled).length;
 
@@ -82,10 +95,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
       }
       logger.info(`Saving movies for "${baseListName}"`);
       logger.debug(`${top10.platform} movies: ${movies}`);
-      if (deps.signal?.aborted) {
-        logger.info('System: Graceful stop requested — halting after current Trakt write');
-        return summary;
-      }
+      if (await abortedBeforeWrite()) return summary;
       await trakt.pushToList(movies, baseListName, 'movie', top10.privacy);
       logger.info(`List ${baseListName} updated with ${movies.length} new movies`);
       summary.moviesAdded += movies.length;
@@ -97,10 +107,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
       }
       logger.info(`Saving shows for "${baseListName}"`);
       logger.debug(`${top10.platform} shows: ${shows}`);
-      if (deps.signal?.aborted) {
-        logger.info('System: Graceful stop requested — halting after current Trakt write');
-        return summary;
-      }
+      if (await abortedBeforeWrite()) return summary;
       await trakt.pushToList(shows, baseListName, 'show', top10.privacy);
       logger.info(`List ${baseListName} updated with ${shows.length} new shows`);
       summary.showsAdded += shows.length;
@@ -119,10 +126,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
       logger.info(`Getting movies for "${listName}"`);
       const popularMovies = await flixpatrol.getPopular('Movies', popular, trakt);
       logger.debug(`${popular.platform} movies: ${popularMovies}`);
-      if (deps.signal?.aborted) {
-        logger.info('System: Graceful stop requested — halting after current Trakt write');
-        return summary;
-      }
+      if (await abortedBeforeWrite()) return summary;
       await trakt.pushToList(popularMovies, listName, 'movie', popular.privacy);
       logger.info(`List ${listName} updated with ${popularMovies.length} new movies`);
       summary.moviesAdded += popularMovies.length;
@@ -133,10 +137,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
       logger.info(`Getting shows for "${listName}"`);
       const popularShows = await flixpatrol.getPopular('TV Shows', popular, trakt);
       logger.debug(`${popular.platform} shows: ${popularShows}`);
-      if (deps.signal?.aborted) {
-        logger.info('System: Graceful stop requested — halting after current Trakt write');
-        return summary;
-      }
+      if (await abortedBeforeWrite()) return summary;
       await trakt.pushToList(popularShows, listName, 'show', popular.privacy);
       logger.info(`List ${listName} updated with ${popularShows.length} new shows`);
       summary.showsAdded += popularShows.length;
@@ -159,10 +160,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
         logger.info(`Getting movies for "${listName}"`);
         const mostWatchedMovies = await flixpatrol.getMostWatched('Movies', mostWatched, trakt);
         logger.debug(`most-watched movies: ${mostWatchedMovies}`);
-        if (deps.signal?.aborted) {
-          logger.info('System: Graceful stop requested — halting after current Trakt write');
-          return summary;
-        }
+        if (await abortedBeforeWrite()) return summary;
         await trakt.pushToList(mostWatchedMovies, listName, 'movie', mostWatched.privacy);
         logger.info(`List ${listName} updated with ${mostWatchedMovies.length} new movies`);
         summary.moviesAdded += mostWatchedMovies.length;
@@ -173,10 +171,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
         logger.info(`Getting shows for "${listName}"`);
         const mostWatchedShows = await flixpatrol.getMostWatched('TV Shows', mostWatched, trakt);
         logger.debug(`most-watched shows: ${mostWatchedShows}`);
-        if (deps.signal?.aborted) {
-          logger.info('System: Graceful stop requested — halting after current Trakt write');
-          return summary;
-        }
+        if (await abortedBeforeWrite()) return summary;
         await trakt.pushToList(mostWatchedShows, listName, 'show', mostWatched.privacy);
         logger.info(`List ${listName} updated with ${mostWatchedShows.length} new shows`);
         summary.showsAdded += mostWatchedShows.length;
@@ -200,10 +195,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
         logger.info(`Getting movies for "${listName}"`);
         const mostHoursMovies = await flixpatrol.getMostHours('Movies', mostHours, trakt);
         logger.debug(`most-hours-${mostHours.period} movies: ${mostHoursMovies}`);
-        if (deps.signal?.aborted) {
-          logger.info('System: Graceful stop requested — halting after current Trakt write');
-          return summary;
-        }
+        if (await abortedBeforeWrite()) return summary;
         await trakt.pushToList(mostHoursMovies, listName, 'movie', mostHours.privacy);
         logger.info(`List ${listName} updated with ${mostHoursMovies.length} new movies`);
         summary.moviesAdded += mostHoursMovies.length;
@@ -214,10 +206,7 @@ export async function runPipeline(deps: RunPipelineDeps): Promise<RunSummary> {
         logger.info(`Getting shows for "${listName}"`);
         const mostHoursShows = await flixpatrol.getMostHours('TV Shows', mostHours, trakt);
         logger.debug(`most-hours-${mostHours.period} shows: ${mostHoursShows}`);
-        if (deps.signal?.aborted) {
-          logger.info('System: Graceful stop requested — halting after current Trakt write');
-          return summary;
-        }
+        if (await abortedBeforeWrite()) return summary;
         await trakt.pushToList(mostHoursShows, listName, 'show', mostHours.privacy);
         logger.info(`List ${listName} updated with ${mostHoursShows.length} new shows`);
         summary.showsAdded += mostHoursShows.length;

--- a/src/Scheduler/Scheduler.ts
+++ b/src/Scheduler/Scheduler.ts
@@ -1,0 +1,66 @@
+import cron from 'node-cron';
+import type { ScheduledTask } from 'node-cron';
+import { logger } from '../Utils';
+
+export interface SchedulerOptions {
+  crons: string[];
+  runOnStart: boolean;
+  runner: (signal: AbortSignal) => Promise<void>;
+  onError: (err: unknown) => Promise<void>;
+}
+
+export class Scheduler {
+  private readonly tasks: ScheduledTask[] = [];
+
+  private isRunning = false;
+
+  private currentRun: Promise<void> | null = null;
+
+  private readonly abortController = new AbortController();
+
+  public constructor(private readonly options: SchedulerOptions) {}
+
+  public start(): void {
+    for (const expr of this.options.crons) {
+      this.tasks.push(cron.schedule(expr, () => { void this.trigger(); }));
+    }
+    const list = this.options.crons.map((c) => `"${c}"`).join(', ');
+    logger.info(`Scheduler started — ${this.options.crons.length} cron(s): ${list}`);
+    if (this.options.runOnStart) {
+      logger.info('Scheduler: runOnStart enabled — triggering initial run');
+      void this.trigger();
+    }
+  }
+
+  private async trigger(): Promise<void> {
+    if (this.isRunning) {
+      logger.warn('Scheduler: run already in progress, skipping this trigger');
+      return;
+    }
+    this.isRunning = true;
+    this.currentRun = (async () => {
+      try {
+        await this.options.runner(this.abortController.signal);
+      } catch (err) {
+        await this.options.onError(err);
+      }
+    })();
+    try {
+      await this.currentRun;
+    } finally {
+      this.isRunning = false;
+      this.currentRun = null;
+    }
+  }
+
+  public async stop(): Promise<void> {
+    this.abortController.abort();
+    for (const task of this.tasks) {
+      await task.stop();
+    }
+    if (this.currentRun) {
+      logger.info('Scheduler: waiting for current run to finish (graceful stop after current Trakt write)');
+      await this.currentRun;
+    }
+  }
+}

--- a/src/Scheduler/Scheduler.ts
+++ b/src/Scheduler/Scheduler.ts
@@ -42,7 +42,11 @@ export class Scheduler {
       try {
         await this.options.runner(this.abortController.signal);
       } catch (err) {
-        await this.options.onError(err);
+        try {
+          await this.options.onError(err);
+        } catch (onErrorErr) {
+          logger.error(`Scheduler: onError handler itself failed: ${(onErrorErr as Error).message}`);
+        }
       }
     })();
     try {

--- a/src/Scheduler/index.ts
+++ b/src/Scheduler/index.ts
@@ -1,0 +1,1 @@
+export * from './Scheduler';

--- a/src/Utils/GetAndValidateConfigs.ts
+++ b/src/Utils/GetAndValidateConfigs.ts
@@ -1,5 +1,6 @@
 import config from 'config';
 import { z } from 'zod';
+import cron from 'node-cron';
 import { ConfigurationError } from './Errors';
 import {
   FlixPatrolTop10Schema,
@@ -9,6 +10,7 @@ import {
   TraktOptionsSchema,
   CacheOptionsSchema,
   NotificationsSchema,
+  ScheduleOptionsSchema,
 } from '../types';
 import type {
   FlixPatrolTop10,
@@ -17,6 +19,7 @@ import type {
   FlixPatrolMostHours,
   TraktAPIOptions,
   CacheOptions,
+  ScheduleOptions,
 } from '../types';
 import type { NotificationsConfig } from '../Notifications/types';
 
@@ -116,6 +119,25 @@ export class GetAndValidateConfigs {
       }
       const data = config.get('Notifications');
       return validateConfig(NotificationsSchema, data, 'Notifications');
+    } catch (err) {
+      if (err instanceof ConfigurationError) throw err;
+      throw new ConfigurationError(`${err}`);
+    }
+  }
+
+  public static getScheduleOptions(): ScheduleOptions {
+    try {
+      const data = config.has('Schedule') ? config.get('Schedule') : {};
+      const options = validateConfig(ScheduleOptionsSchema, data, 'Schedule');
+      if (options.enabled) {
+        const invalid = options.crons.filter((expr) => !cron.validate(expr));
+        if (invalid.length > 0) {
+          throw new ConfigurationError(
+            `Schedule.crons contains invalid cron expression(s): ${invalid.map((e) => `"${e}"`).join(', ')}`,
+          );
+        }
+      }
+      return options;
     } catch (err) {
       if (err instanceof ConfigurationError) throw err;
       throw new ConfigurationError(`${err}`);

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -143,6 +143,11 @@ export class Utils {
           run_end: [],
           error: [],
         },
+        Schedule: {
+          enabled: false,
+          crons: ['0 6 * * *'],
+          runOnStart: false,
+        },
       };
 
       fs.writeFileSync('./config/default.json', JSON.stringify(defaultConfig, null, 2) + '\n');

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { logger, Utils, AppError, getPackageInfo } from './Utils';
 import { NotificationManager } from './Notifications';
 import type {
@@ -120,7 +121,12 @@ async function bootstrapConfigs(): Promise<{
 async function main(): Promise<void> {
   const { deps, schedule } = await bootstrapConfigs();
 
-  if (!schedule.enabled) {
+  const authenticated = fs.existsSync(deps.traktOptions.saveFile);
+  if (schedule.enabled && !authenticated) {
+    logger.warn(`Schedule is enabled but no Trakt token file (${deps.traktOptions.saveFile}) exists yet — running once to complete Trakt authentication. The scheduler will start on the next launch, once a token has been saved.`);
+  }
+
+  if (!schedule.enabled || !authenticated) {
     // One-shot mode: unchanged behaviour.
     let shuttingDown = false;
     process.on('SIGINT', async () => {
@@ -172,7 +178,13 @@ async function main(): Promise<void> {
     },
   });
 
+  let daemonShuttingDown = false;
   const shutdown = async (signalName: string): Promise<void> => {
+    if (daemonShuttingDown) {
+      logger.warn('System: Force exit on second signal');
+      process.exit(130);
+    }
+    daemonShuttingDown = true;
     logger.info(`System: Received ${signalName} — stopping scheduler`);
     await scheduler.stop();
     await flushPendingDispatches();

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,21 +1,14 @@
-import { FlixPatrol } from './Flixpatrol';
 import { logger, Utils, AppError, getPackageInfo } from './Utils';
 import { NotificationManager } from './Notifications';
 import type {
   NotificationEvent,
   NotificationPayload,
-  RunSummary,
 } from './Notifications';
-import type {
-  CacheOptions,
-  FlixPatrolMostWatched,
-  FlixPatrolMostHours,
-  FlixPatrolPopular,
-  FlixPatrolTop10,
-  TraktAPIOptions,
-} from './types';
+import type { ScheduleOptions } from './types';
 import { GetAndValidateConfigs } from './Utils/GetAndValidateConfigs';
-import { TraktAPI } from './Trakt';
+import { runPipeline } from './Pipeline';
+import type { RunPipelineDeps } from './Pipeline';
+import { Scheduler } from './Scheduler';
 
 const { name, version } = getPackageInfo();
 
@@ -98,243 +91,101 @@ async function dispatchErrorAndExit(err: unknown, exitCode = 1): Promise<never> 
   process.exit(exitCode);
 }
 
-async function run(): Promise<void> {
-  // Definite-assignment via `!`: each var is assigned inside the try; on a
-  // throw the catch calls dispatchErrorAndExit which terminates the process,
-  // so any access after the try implicitly runs only when the assignments
-  // succeeded. TS's flow analysis cannot prove this across an awaited
-  // Promise<never>, hence the assertion.
-  let cacheOptions!: CacheOptions;
-  let traktOptions!: TraktAPIOptions;
-  let flixPatrolTop10!: FlixPatrolTop10[];
-  let flixPatrolPopulars!: FlixPatrolPopular[];
-  let flixPatrolMostWatched!: FlixPatrolMostWatched[];
-  let flixPatrolMostHours!: FlixPatrolMostHours[];
-
+async function bootstrapConfigs(): Promise<{
+  deps: Omit<RunPipelineDeps, 'signal'>;
+  schedule: ScheduleOptions;
+}> {
   try {
     logger.info('Loading all configurations values');
-    cacheOptions = GetAndValidateConfigs.getCacheOptions();
-    traktOptions = GetAndValidateConfigs.getTraktOptions();
-    flixPatrolTop10 = GetAndValidateConfigs.getFlixPatrolTop10();
-    flixPatrolPopulars = GetAndValidateConfigs.getFlixPatrolPopular();
-    flixPatrolMostWatched = GetAndValidateConfigs.getFlixPatrolMostWatched();
-    flixPatrolMostHours = GetAndValidateConfigs.getFlixPatrolMostHours();
-  } catch (err) {
-    await dispatchErrorAndExit(err);
-  }
-
-  // Everything past this point is wrapped in one try/catch so any throw — from
-  // .filter / JSON.stringify, the FlixPatrol/TraktAPI constructors, trakt.connect,
-  // or the list-processing loops — gets routed through dispatchErrorAndExit and
-  // delivers an 'error' notification.
-  try {
-    const enabledMostWatched = flixPatrolMostWatched.filter((m) => m.enabled).length;
-    const enabledMostHours = flixPatrolMostHours.filter((m) => m.enabled).length;
-
-    logger.debug(`Config loaded: ${flixPatrolTop10.length} Top10, ${flixPatrolPopulars.length} Popular, ${enabledMostWatched} MostWatched, ${enabledMostHours} MostHours, cache ${cacheOptions.enabled ? 'enabled' : 'disabled'}`);
-
-    logger.silly(`cacheOptions: ${JSON.stringify(cacheOptions)}`);
-    logger.silly(`traktOptions: ${JSON.stringify({...traktOptions, clientId: 'REDACTED', clientSecret: 'REDACTED'})}`);
-    logger.silly(`flixPatrolTop10: ${JSON.stringify(flixPatrolTop10)}`);
-    logger.silly(`flixPatrolPopulars: ${JSON.stringify(flixPatrolPopulars)}`);
-    logger.silly(`flixPatrolMostWatched: ${JSON.stringify(flixPatrolMostWatched)}`);
-    logger.silly(`flixPatrolMostHours: ${JSON.stringify(flixPatrolMostHours)}`);
-
-    const flixpatrol = new FlixPatrol(cacheOptions);
-    const trakt = new TraktAPI({ ...traktOptions, dryRun });
-
-    const totalLists = flixPatrolTop10.length
-      + flixPatrolPopulars.length
-      + enabledMostWatched
-      + enabledMostHours;
-    let currentList = 0;
-    const runStartAt = Date.now();
-    const summary: RunSummary = {
-      listsProcessed: 0,
-      moviesAdded: 0,
-      showsAdded: 0,
-      durationMs: 0,
+    const deps: Omit<RunPipelineDeps, 'signal'> = {
+      cacheOptions: GetAndValidateConfigs.getCacheOptions(),
+      traktOptions: GetAndValidateConfigs.getTraktOptions(),
+      flixPatrolTop10: GetAndValidateConfigs.getFlixPatrolTop10(),
+      flixPatrolPopulars: GetAndValidateConfigs.getFlixPatrolPopular(),
+      flixPatrolMostWatched: GetAndValidateConfigs.getFlixPatrolMostWatched(),
+      flixPatrolMostHours: GetAndValidateConfigs.getFlixPatrolMostHours(),
+      dispatch,
+      dryRun,
+      listNamePrefix,
+      appName: name,
+      appVersion: version,
     };
-
-    await trakt.connect();
-
-    // Fire-and-forget: do not block the pipeline on the notification round-trip.
-    // The dispatch is tracked in pendingDispatches so it gets flushed before
-    // any process.exit (even on a fast-failing run).
-    void dispatch('run_start', {
-      title: `${dryRunTag}${name} v${version} run started`,
-      body: `Processing ${totalLists} lists`,
-      timestamp: new Date().toISOString(),
-    });
-
-    for (const top10 of flixPatrolTop10) {
-      currentList++;
-      const defaultName = `${top10.platform}-${top10.location}-top10-${top10.fallback === false ? 'without-fallback' : `with-${top10.fallback}-fallback`}`;
-      const baseListName = Utils.getListName(top10, defaultName, listNamePrefix);
-      logger.info('==============================');
-      logger.info(`[${currentList}/${totalLists}] Processing "${baseListName}"`);
-
-      const { movies, shows, rawCounts } = await flixpatrol.getTop10Sections(top10, trakt);
-
-      if (movies.length > 0) {
-        logger.info('==============================');
-        if (rawCounts.movies > movies.length) {
-          logger.warn(`Some movies from FlixPatrol could not be matched on Trakt (${rawCounts.movies} found, ${movies.length} matched)`);
-        }
-        logger.info(`Saving movies for "${baseListName}"`);
-        logger.debug(`${top10.platform} movies: ${movies}`);
-        await trakt.pushToList(movies, baseListName, 'movie', top10.privacy);
-        logger.info(`List ${baseListName} updated with ${movies.length} new movies`);
-        summary.moviesAdded += movies.length;
-      }
-      if (shows.length > 0) {
-        logger.info('==============================');
-        if (rawCounts.shows > shows.length) {
-          logger.warn(`Some shows from FlixPatrol could not be matched on Trakt (${rawCounts.shows} found, ${shows.length} matched)`);
-        }
-        logger.info(`Saving shows for "${baseListName}"`);
-        logger.debug(`${top10.platform} shows: ${shows}`);
-        await trakt.pushToList(shows, baseListName, 'show', top10.privacy);
-        logger.info(`List ${baseListName} updated with ${shows.length} new shows`);
-        summary.showsAdded += shows.length;
-      }
-      summary.listsProcessed++;
-    }
-
-
-    for (const popular of flixPatrolPopulars) {
-      currentList++;
-      const listName = Utils.getListName(popular, `${popular.platform}-popular`, listNamePrefix);
-      logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
-
-      if (popular.type === 'movies' || popular.type === 'both') {
-        logger.info('==============================');
-        logger.info(`Getting movies for "${listName}"`);
-        const popularMovies = await flixpatrol.getPopular('Movies', popular, trakt);
-        logger.debug(`${popular.platform} movies: ${popularMovies}`);
-        await trakt.pushToList(popularMovies, listName, 'movie', popular.privacy);
-        logger.info(`List ${listName} updated with ${popularMovies.length} new movies`);
-        summary.moviesAdded += popularMovies.length;
-      }
-
-      if (popular.type === 'shows' || popular.type === 'both') {
-        logger.info('==============================');
-        logger.info(`Getting shows for "${listName}"`);
-        const popularShows = await flixpatrol.getPopular('TV Shows', popular, trakt);
-        logger.debug(`${popular.platform} shows: ${popularShows}`);
-        await trakt.pushToList(popularShows, listName, 'show', popular.privacy);
-        logger.info(`List ${listName} updated with ${popularShows.length} new shows`);
-        summary.showsAdded += popularShows.length;
-      }
-      summary.listsProcessed++;
-    }
-
-    for (const mostWatched of flixPatrolMostWatched) {
-      if (mostWatched.enabled) {
-        currentList++;
-        let defaultName = `most-watched-${mostWatched.year}-netflix`;
-        defaultName = mostWatched.original !== undefined ? `${defaultName}-original` : defaultName;
-        defaultName = mostWatched.premiere !== undefined ? `${defaultName}-${mostWatched.premiere}-premiere` : defaultName;
-        defaultName = mostWatched.country !== undefined ? `${defaultName}-from-${mostWatched.country}` : defaultName;
-        const listName = Utils.getListName(mostWatched, defaultName, listNamePrefix);
-        logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
-
-        if (mostWatched.type === 'movies' || mostWatched.type === 'both') {
-          logger.info('==============================');
-          logger.info(`Getting movies for "${listName}"`);
-          const mostWatchedMovies = await flixpatrol.getMostWatched('Movies', mostWatched, trakt);
-          logger.debug(`most-watched movies: ${mostWatchedMovies}`);
-          await trakt.pushToList(mostWatchedMovies, listName, 'movie', mostWatched.privacy);
-          logger.info(`List ${listName} updated with ${mostWatchedMovies.length} new movies`);
-          summary.moviesAdded += mostWatchedMovies.length;
-        }
-
-        if (mostWatched.type === 'shows' || mostWatched.type === 'both') {
-          logger.info('==============================');
-          logger.info(`Getting shows for "${listName}"`);
-          const mostWatchedShows = await flixpatrol.getMostWatched('TV Shows', mostWatched, trakt);
-          logger.debug(`most-watched shows: ${mostWatchedShows}`);
-          await trakt.pushToList(mostWatchedShows, listName, 'show', mostWatched.privacy);
-          logger.info(`List ${listName} updated with ${mostWatchedShows.length} new shows`);
-          summary.showsAdded += mostWatchedShows.length;
-        }
-        summary.listsProcessed++;
-      }
-    }
-
-    for (const mostHours of flixPatrolMostHours) {
-      if (mostHours.enabled) {
-        currentList++;
-        let defaultName = `netflix-most-hours-${mostHours.period}`;
-        if (mostHours.language !== 'all') {
-          defaultName += `-${mostHours.language}`;
-        }
-        const listName = Utils.getListName(mostHours, defaultName, listNamePrefix);
-        logger.info(`[${currentList}/${totalLists}] Processing "${listName}"`);
-
-        if (mostHours.type === 'movies' || mostHours.type === 'both') {
-          logger.info('==============================');
-          logger.info(`Getting movies for "${listName}"`);
-          const mostHoursMovies = await flixpatrol.getMostHours('Movies', mostHours, trakt);
-          logger.debug(`most-hours-${mostHours.period} movies: ${mostHoursMovies}`);
-          await trakt.pushToList(mostHoursMovies, listName, 'movie', mostHours.privacy);
-          logger.info(`List ${listName} updated with ${mostHoursMovies.length} new movies`);
-          summary.moviesAdded += mostHoursMovies.length;
-        }
-
-        if (mostHours.type === 'shows' || mostHours.type === 'both') {
-          logger.info('==============================');
-          logger.info(`Getting shows for "${listName}"`);
-          const mostHoursShows = await flixpatrol.getMostHours('TV Shows', mostHours, trakt);
-          logger.debug(`most-hours-${mostHours.period} shows: ${mostHoursShows}`);
-          await trakt.pushToList(mostHoursShows, listName, 'show', mostHours.privacy);
-          logger.info(`List ${listName} updated with ${mostHoursShows.length} new shows`);
-          summary.showsAdded += mostHoursShows.length;
-        }
-        summary.listsProcessed++;
-      }
-    }
-
-    summary.durationMs = Date.now() - runStartAt;
-    const movedVerb = dryRun ? 'would be added' : 'added';
-    await dispatch('run_end', {
-      title: `${dryRunTag}${name} run finished`,
-      body: `${dryRunTag}Processed ${summary.listsProcessed}/${totalLists} lists in ${Math.round(summary.durationMs / 1000)}s — ${summary.moviesAdded} movies / ${summary.showsAdded} shows ${movedVerb}`,
-      timestamp: new Date().toISOString(),
-      summary,
-    });
-    await flushPendingDispatches();
+    const schedule = GetAndValidateConfigs.getScheduleOptions();
+    return { deps, schedule };
   } catch (err) {
-    await dispatchErrorAndExit(err);
+    return dispatchErrorAndExit(err);
   }
 }
 
-let shuttingDown = false;
-process.on('SIGINT', async () => {
-  if (shuttingDown) {
-    logger.warn('System: Force exit on second SIGINT signal');
-    process.exit(130);
-  }
-  shuttingDown = true;
-  logger.info('System: Receive SIGINT signal');
-  // If the catch block is already dispatching an error, don't queue a duplicate
-  // — the user would receive two notifications ("run failed" + "run aborted")
-  // for what is logically one incident.
-  if (!errorDispatchInFlight) {
-    await dispatch('error', {
-      title: `${dryRunTag}${name} run aborted`,
-      body: 'The run was interrupted by SIGINT',
-      timestamp: new Date().toISOString(),
-    });
-  }
-  await flushPendingDispatches();
-  logger.info('System: Application stopped');
-  // 130 = 128 + SIGINT (2); the standard Unix convention for "terminated by Ctrl-C".
-  // Cron/systemd unit branching on $? will correctly see this as a failed run.
-  process.exit(130);
-});
+async function main(): Promise<void> {
+  const { deps, schedule } = await bootstrapConfigs();
 
-run().catch((err: unknown) => {
+  if (!schedule.enabled) {
+    // One-shot mode: unchanged behaviour.
+    let shuttingDown = false;
+    process.on('SIGINT', async () => {
+      if (shuttingDown) {
+        logger.warn('System: Force exit on second SIGINT signal');
+        process.exit(130);
+      }
+      shuttingDown = true;
+      logger.info('System: Receive SIGINT signal');
+      // If the catch block is already dispatching an error, don't queue a duplicate
+      // — the user would receive two notifications ("run failed" + "run aborted")
+      // for what is logically one incident.
+      if (!errorDispatchInFlight) {
+        await dispatch('error', {
+          title: `${dryRunTag}${name} run aborted`,
+          body: 'The run was interrupted by SIGINT',
+          timestamp: new Date().toISOString(),
+        });
+      }
+      await flushPendingDispatches();
+      logger.info('System: Application stopped');
+      // 130 = 128 + SIGINT (2); the standard Unix convention for "terminated by Ctrl-C".
+      // Cron/systemd unit branching on $? will correctly see this as a failed run.
+      process.exit(130);
+    });
+
+    try {
+      await runPipeline(deps);
+      await flushPendingDispatches();
+    } catch (err) {
+      await dispatchErrorAndExit(err);
+    }
+    return;
+  }
+
+  // Daemon mode.
+  const scheduler = new Scheduler({
+    crons: schedule.crons,
+    runOnStart: schedule.runOnStart,
+    runner: (signal) => runPipeline({ ...deps, signal }).then(() => undefined),
+    onError: async (err) => {
+      logger.error(`Run failed: ${(err as Error).message}`);
+      await dispatch('error', {
+        title: `${dryRunTag}${name} run failed`,
+        body: `${(err as Error).name}: ${(err as Error).message}`,
+        timestamp: new Date().toISOString(),
+      });
+      await flushPendingDispatches();
+    },
+  });
+
+  const shutdown = async (signalName: string): Promise<void> => {
+    logger.info(`System: Received ${signalName} — stopping scheduler`);
+    await scheduler.stop();
+    await flushPendingDispatches();
+    logger.info('System: Application stopped');
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
+  process.on('SIGINT', () => { void shutdown('SIGINT'); });
+
+  scheduler.start();
+}
+
+main().catch((err: unknown) => {
   logger.error(`Unexpected bootstrap error: ${(err as Error).message}`);
   process.exit(1);
 });

--- a/src/types/Config.types.ts
+++ b/src/types/Config.types.ts
@@ -148,6 +148,15 @@ export const NotificationsSchema = z.object({
   error: z.array(DestinationSchema).optional(),
 });
 
+export const ScheduleOptionsSchema = z.object({
+  enabled: z.boolean().default(false),
+  crons: z.array(z.string()).default([]),
+  runOnStart: z.boolean().default(false),
+}).refine(
+  (s) => !s.enabled || s.crons.length > 0,
+  { message: 'crons must contain at least one expression when enabled' },
+);
+
 // Infer types from schemas
 export type FlixPatrolTop10 = z.infer<typeof FlixPatrolTop10Schema>;
 export type FlixPatrolPopular = z.infer<typeof FlixPatrolPopularSchema>;
@@ -158,3 +167,4 @@ export type FlixPatrolMostHoursLanguage = z.infer<typeof FlixPatrolMostHoursLang
 export type TraktAPIOptions = z.infer<typeof TraktOptionsSchema>;
 export type CacheOptions = z.infer<typeof CacheOptionsSchema>;
 export type NotificationsConfigFromSchema = z.infer<typeof NotificationsSchema>;
+export type ScheduleOptions = z.infer<typeof ScheduleOptionsSchema>;

--- a/tests/Pipeline/runPipeline.test.ts
+++ b/tests/Pipeline/runPipeline.test.ts
@@ -58,6 +58,9 @@ describe('runPipeline abort checkpoint', () => {
     });
     await runPipeline(deps);
     expect(pushToList).not.toHaveBeenCalled();
+    expect(deps.dispatch).toHaveBeenCalledWith('error', expect.objectContaining({
+      title: expect.stringContaining('run interrupted'),
+    }));
   });
 
   it('performs writes when the signal is not aborted', async () => {
@@ -72,5 +75,8 @@ describe('runPipeline abort checkpoint', () => {
     });
     await runPipeline(deps);
     expect(pushToList).toHaveBeenCalledTimes(1);
+    expect(deps.dispatch).not.toHaveBeenCalledWith('error', expect.objectContaining({
+      title: expect.stringContaining('run interrupted'),
+    }));
   });
 });

--- a/tests/Pipeline/runPipeline.test.ts
+++ b/tests/Pipeline/runPipeline.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const pushToList = vi.fn().mockResolvedValue(undefined);
+const connect = vi.fn().mockResolvedValue(undefined);
+const getTop10Sections = vi.fn();
+
+vi.mock('../../src/Trakt', () => ({
+  TraktAPI: vi.fn().mockImplementation(function TraktAPIMock() { return { connect, pushToList }; }),
+}));
+vi.mock('../../src/Flixpatrol', () => ({
+  FlixPatrol: vi.fn().mockImplementation(function FlixPatrolMock() { return { getTop10Sections }; }),
+}));
+vi.mock('../../src/Utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/Utils')>();
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), silly: vi.fn(), level: 'info' },
+  };
+});
+
+import { runPipeline } from '../../src/Pipeline/runPipeline';
+import type { RunPipelineDeps } from '../../src/Pipeline/runPipeline';
+
+function baseDeps(overrides: Partial<RunPipelineDeps> = {}): RunPipelineDeps {
+  return {
+    cacheOptions: { enabled: false, savePath: '/tmp', ttl: 1 },
+    traktOptions: { saveFile: '/tmp/t', clientId: 'id', clientSecret: 'secret' },
+    flixPatrolTop10: [],
+    flixPatrolPopulars: [],
+    flixPatrolMostWatched: [],
+    flixPatrolMostHours: [],
+    dispatch: vi.fn().mockResolvedValue(undefined),
+    dryRun: false,
+    listNamePrefix: '',
+    appName: 'flixpatrol-top10',
+    appVersion: 'test',
+    ...overrides,
+  };
+}
+
+describe('runPipeline abort checkpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops before the next Trakt write when the signal is already aborted', async () => {
+    getTop10Sections.mockResolvedValue({
+      movies: [1, 2], shows: [3, 4], rawCounts: { movies: 2, shows: 2 },
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const deps = baseDeps({
+      flixPatrolTop10: [{
+        platform: 'netflix', location: 'world', fallback: false,
+        privacy: 'private', limit: 10, type: 'both',
+      }] as never,
+      signal: controller.signal,
+    });
+    await runPipeline(deps);
+    expect(pushToList).not.toHaveBeenCalled();
+  });
+
+  it('performs writes when the signal is not aborted', async () => {
+    getTop10Sections.mockResolvedValue({
+      movies: [1, 2], shows: [], rawCounts: { movies: 2, shows: 0 },
+    });
+    const deps = baseDeps({
+      flixPatrolTop10: [{
+        platform: 'netflix', location: 'world', fallback: false,
+        privacy: 'private', limit: 10, type: 'both',
+      }] as never,
+    });
+    await runPipeline(deps);
+    expect(pushToList).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Scheduler/Scheduler.test.ts
+++ b/tests/Scheduler/Scheduler.test.ts
@@ -84,6 +84,26 @@ describe('Scheduler', () => {
     expect(runner).toHaveBeenCalledTimes(2);
   });
 
+  it('survives a runner rejection AND an onError rejection without crashing, and stays alive for the next trigger', async () => {
+    const onError = vi.fn().mockRejectedValue(new Error('onError boom'));
+    const runner = vi.fn().mockRejectedValue(new Error('runner boom'));
+    const scheduler = new Scheduler({
+      crons: ['* * * * *'], runOnStart: true, runner, onError,
+    });
+    // start() must not throw and must not produce an unhandled rejection.
+    expect(() => scheduler.start()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining('onError handler itself failed'),
+    );
+    // A later cron trigger still invokes runner again (daemon survived both rejections).
+    const tick = vi.mocked(cron.schedule).mock.calls[0][1] as () => void;
+    tick();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
   it('stop() aborts the signal, stops tasks and awaits the in-flight run', async () => {
     const d = deferred<void>();
     let received: AbortSignal | undefined;

--- a/tests/Scheduler/Scheduler.test.ts
+++ b/tests/Scheduler/Scheduler.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node-cron', () => ({
+  default: {
+    schedule: vi.fn(() => ({ stop: vi.fn() })),
+    validate: vi.fn(() => true),
+  },
+}));
+
+vi.mock('../../src/Utils', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import cron from 'node-cron';
+import { logger } from '../../src/Utils';
+import { Scheduler } from '../../src/Scheduler/Scheduler';
+
+// A promise we can resolve/reject on demand to control run timing.
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe('Scheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('schedules one cron task per expression', () => {
+    const scheduler = new Scheduler({
+      crons: ['0 6 * * *', '0 18 * * *'],
+      runOnStart: false,
+      runner: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    });
+    scheduler.start();
+    expect(vi.mocked(cron.schedule)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not run on start when runOnStart is false', () => {
+    const runner = vi.fn().mockResolvedValue(undefined);
+    new Scheduler({ crons: ['* * * * *'], runOnStart: false, runner, onError: vi.fn() }).start();
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('runs immediately on start when runOnStart is true', async () => {
+    const runner = vi.fn().mockResolvedValue(undefined);
+    new Scheduler({ crons: ['* * * * *'], runOnStart: true, runner, onError: vi.fn() }).start();
+    await Promise.resolve();
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a trigger while a run is already in progress', async () => {
+    const d = deferred<void>();
+    const runner = vi.fn().mockReturnValue(d.promise);
+    const scheduler = new Scheduler({
+      crons: ['* * * * *'], runOnStart: false, runner, onError: vi.fn(),
+    });
+    scheduler.start();
+    const tick = vi.mocked(cron.schedule).mock.calls[0][1] as () => void;
+    tick(); // first run starts, isRunning = true
+    tick(); // should be skipped
+    await Promise.resolve();
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalled();
+    d.resolve();
+  });
+
+  it('survives a runner rejection and routes it to onError', async () => {
+    const onError = vi.fn().mockResolvedValue(undefined);
+    const runner = vi.fn().mockRejectedValue(new Error('boom'));
+    const scheduler = new Scheduler({
+      crons: ['* * * * *'], runOnStart: true, runner, onError,
+    });
+    scheduler.start();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    // A later trigger runs again (daemon stayed alive).
+    const tick = vi.mocked(cron.schedule).mock.calls[0][1] as () => void;
+    tick();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() aborts the signal, stops tasks and awaits the in-flight run', async () => {
+    const d = deferred<void>();
+    let received: AbortSignal | undefined;
+    let runSettled = false;
+    const runner = vi.fn((signal: AbortSignal) => {
+      received = signal;
+      return d.promise.then(() => { runSettled = true; });
+    });
+    const task = { stop: vi.fn() };
+    vi.mocked(cron.schedule).mockReturnValue(task as never);
+    const scheduler = new Scheduler({
+      crons: ['* * * * *'], runOnStart: true, runner, onError: vi.fn(),
+    });
+    scheduler.start();
+    await Promise.resolve();
+    const stopPromise = scheduler.stop();
+    expect(received?.aborted).toBe(true);
+    expect(task.stop).toHaveBeenCalled();
+
+    // stop() must stay pending until the in-flight run settles.
+    let stopSettled = false;
+    void stopPromise.then(() => { stopSettled = true; });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(stopSettled).toBe(false);
+    expect(runSettled).toBe(false);
+
+    d.resolve();
+    await stopPromise;
+    expect(runSettled).toBe(true);
+    expect(stopSettled).toBe(true);
+  });
+});

--- a/tests/Utils/GetAndValidateConfigs.test.ts
+++ b/tests/Utils/GetAndValidateConfigs.test.ts
@@ -402,5 +402,37 @@ describe('GetAndValidateConfigs', () => {
         expect(() => GetAndValidateConfigs.getNotifications()).toThrow(/key/);
       });
     });
+
+    describe('getScheduleOptions', () => {
+      it('returns disabled defaults when the Schedule block is absent', () => {
+        vi.mocked(config.has).mockReturnValue(false);
+        const result = GetAndValidateConfigs.getScheduleOptions();
+        expect(result).toEqual({ enabled: false, crons: [], runOnStart: false });
+      });
+
+      it('returns a valid enabled schedule', () => {
+        vi.mocked(config.has).mockReturnValue(true);
+        vi.mocked(config.get).mockReturnValue({
+          enabled: true, crons: ['0 6 * * *', '0 18 * * *'], runOnStart: true,
+        });
+        const result = GetAndValidateConfigs.getScheduleOptions();
+        expect(result).toEqual({
+          enabled: true, crons: ['0 6 * * *', '0 18 * * *'], runOnStart: true,
+        });
+      });
+
+      it('throws when enabled with no crons', () => {
+        vi.mocked(config.has).mockReturnValue(true);
+        vi.mocked(config.get).mockReturnValue({ enabled: true, crons: [] });
+        expect(() => GetAndValidateConfigs.getScheduleOptions()).toThrow(ConfigurationError);
+      });
+
+      it('throws when a cron expression is invalid', () => {
+        vi.mocked(config.has).mockReturnValue(true);
+        vi.mocked(config.get).mockReturnValue({ enabled: true, crons: ['not a cron'] });
+        expect(() => GetAndValidateConfigs.getScheduleOptions())
+          .toThrow(/invalid cron expression/i);
+      });
+    });
   });
 });

--- a/tests/Utils/Utils.test.ts
+++ b/tests/Utils/Utils.test.ts
@@ -194,6 +194,7 @@ describe('Utils', () => {
       expect(parsed).toHaveProperty('FlixPatrolMostWatched');
       expect(parsed).toHaveProperty('Trakt');
       expect(parsed).toHaveProperty('Cache');
+      expect(parsed).toHaveProperty('Schedule');
     });
 
     it('should include Netflix and Disney in FlixPatrolTop10', () => {


### PR DESCRIPTION
## Description
Adds an optional **daemon mode** with built-in cron scheduling, so the app can run as a long-lived process instead of relying on an external cron / `docker run` on a timer.

New optional `Schedule` block in the config:
```json
"Schedule": {
  "enabled": true,
  "crons": ["0 6 * * *", "0 18 * * *"],
  "runOnStart": false
}
```
- `enabled` — turn daemon mode on (default `false`; when off/absent the app runs once and exits, **fully backward compatible**).
- `crons` — one or more 5-field cron expressions (validated at startup via `node-cron`).
- `runOnStart` — also run immediately at startup.

Behaviour:
- Overlapping triggers are **skipped** while a run is in progress.
- A failed run is logged + notified (existing `error` event) but **does not kill the daemon**.
- Graceful shutdown on `SIGTERM`/`SIGINT` (e.g. `docker stop`): finishes the current Trakt write, then halts before the next one; a second signal force-exits (130). An interruption notification is dispatched.
- Timezone follows the system clock / `TZ` env var.
- If daemon mode is enabled but no Trakt token exists yet, the app falls back to a single interactive run so the device-flow can authenticate; the scheduler starts on the next launch.

Implementation: extracted the run pipeline into a testable `runPipeline()` (throws instead of `process.exit`), added a `Scheduler` module wrapping `node-cron`, and turned `app.ts` into a thin bootstrap that routes to one-shot or daemon mode.

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 215/215

## Related Issues
