### PR TITLE
chore(renovate): fix auto-merge via app-API merge (platformAutomerge false)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,8 @@
     "develop"
   ],
   "schedule": ["before 6am on monday"],
+  "platformAutomerge": false,
+  "automergeSchedule": ["at any time"],
   "packageRules": [
     {
       "description": "Group and auto-merge npm minor and patch updates",


### PR DESCRIPTION
## Description
Fix Renovate auto-merge on `develop`, which was stuck (`mergeable_state: blocked`) despite green checks and the Renovate bypass actor.

Root cause: Renovate defaulted to `platformAutomerge: true` (GitHub **native** auto-merge). Native auto-merge does **not** apply ruleset bypass actors, so the required-review rule kept blocking the PR forever — the bypass we granted Renovate was never exercised.

Fix (config read from the default branch, hence this PR targets `main`):
- `platformAutomerge: false` — Renovate merges via its own API call, authenticated as the Renovate app, which **is** a bypass actor on the `develop` ruleset → the merge bypasses the required review.
- `automergeSchedule: ["at any time"]` — decouples merging from the weekly `schedule`, so a PR created Monday auto-merges as soon as its checks are green (on any Renovate run), instead of waiting for the next weekly window.

Human PRs still require manual review (only the Renovate app bypasses, via `bypass_mode: pull_request`).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally (renovate-config-validator: valid)
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
Follow-up to the Renovate migration (auto-merge on develop).
