### PR TITLE
fix(config): align default config sources, refresh stale documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,24 @@ npm install          # Install dependencies
 npm run build        # Build TypeScript to build/
 npm run start        # Build and run
 npm run start:dev    # Development mode with nodemon hot reload
+npm test             # Run the test suite once (vitest)
+npm run test:watch   # Run tests in watch mode
+npm run test:coverage # Run tests with coverage (reports in .reports/coverage)
 npm run lint         # Run ESLint
 npm run lint-and-fix # Run ESLint with auto-fix
 npm run package      # Create cross-platform binaries in bin/
 ```
+
+### Environment Variables
+
+| Variable | Effect |
+|---|---|
+| `LOG_LEVEL` | `error`, `warn`, `info` (default), `debug`, `silly` |
+| `DRY_RUN` | `true` skips every Trakt write; lists are computed and logged only |
+| `LIST_NAME_PREFIX` | Prefixes every list name, e.g. `[TEST]`. Use it for local runs so real lists are never touched |
+
+When running the app locally to verify a change by hand, always set
+`LIST_NAME_PREFIX="[TEST]"` so nothing writes to the real lists.
 
 ## Architecture Overview
 
@@ -22,7 +36,7 @@ TypeScript CLI tool that scrapes FlixPatrol for streaming platform top 10 lists 
 
 ```
 src/
-├── app.ts                      # Entry point
+├── app.ts                      # Entry point: bootstrap, one-shot vs daemon mode
 ├── Flixpatrol/
 │   ├── index.ts                # Exports FlixPatrol class and types
 │   └── FlixPatrol.ts           # Web scraping logic
@@ -32,10 +46,30 @@ src/
 ├── Trakt/
 │   ├── index.ts                # Exports TraktAPI class and types
 │   └── TraktAPI.ts             # Trakt.tv API wrapper
+├── Pipeline/
+│   ├── index.ts                # Exports runPipeline
+│   └── runPipeline.ts          # One run: FlareSolverr session lifecycle + all list processing
+├── Scheduler/
+│   ├── index.ts                # Exports Scheduler
+│   └── Scheduler.ts            # Daemon mode: cron-driven repeated runs
+├── Notifications/
+│   ├── index.ts                # Exports NotificationManager and types
+│   ├── NotificationManager.ts  # Dispatches events to configured destinations
+│   ├── Notifier.ts             # Notifier interface
+│   ├── http.ts                 # POST helper with timeout and no-throw contract
+│   ├── types.ts                # Notification config/event types
+│   └── adapters/               # webhook, gotify, ntfy, apprise
+├── types/
+│   ├── index.ts                # Barrel for all types
+│   ├── Config.types.ts         # Zod schemas + inferred config types
+│   ├── FlixPatrol.types.ts     # Platform/location/type unions
+│   └── Trakt.types.ts          # Trakt id types
 └── Utils/
-    ├── index.ts                # Exports logger and Utils
+    ├── index.ts                # Exports logger, Utils, errors, package info
     ├── Logger.ts               # Winston logger config
-    ├── Utils.ts                # Helper functions (sleep, ensureConfigExist)
+    ├── Utils.ts                # Helper functions (sleep, getListName, ensureConfigExist)
+    ├── Errors.ts               # AppError + Configuration/FlixPatrol/Trakt/FlareSolverr errors
+    ├── getPackageInfo.ts       # Reads name/version for logs and notifications
     └── GetAndValidateConfigs.ts # Config validation
 ```
 
@@ -43,13 +77,32 @@ src/
 
 **`src/app.ts`** - Entry point flow:
 1. `Utils.ensureConfigExist()` - creates default config if missing
-2. Loads and validates all configurations via `GetAndValidateConfigs`
-3. Calls `runPipeline()`, which:
-   1. Creates the FlareSolverr session, if enabled
-   2. Initializes `FlixPatrol` and `TraktAPI` instances
-   3. Calls `trakt.connect()` (OAuth device flow)
-   4. Processes Top10 → Popular → MostWatched lists sequentially (for each: scrape FlixPatrol → convert to Trakt IDs → sync list)
-   5. Destroys the FlareSolverr session in a `finally` block, once the run ends
+2. Builds the `NotificationManager` early, so later failures can be notified. Two failures cannot be: a config file that can't be written, and a broken `Notifications` block — no working notifier exists yet at that point.
+3. Loads and validates all configurations via `GetAndValidateConfigs`
+4. Branches on `Schedule.enabled`:
+   - **one-shot** (default, or when no Trakt token exists yet): runs the pipeline once, then exits. `SIGINT` dispatches an `error` notification and exits 130.
+   - **daemon**: hands the pipeline to `Scheduler`, which re-runs it on each cron tick. `SIGTERM`/`SIGINT` stop the scheduler gracefully.
+5. Every exit path flushes pending notification dispatches before `process.exit`, so fire-and-forget notifications are not cut off.
+
+**`src/Pipeline/runPipeline.ts`** - One run:
+1. Creates the FlareSolverr session, if enabled (before any list, so a dead container fails fast)
+2. Initializes `FlixPatrol` and `TraktAPI` instances
+3. Calls `trakt.connect()` (OAuth device flow)
+4. Dispatches `run_start`, then processes Top10 → Popular → MostWatched → MostHours sequentially (for each: scrape FlixPatrol → convert to Trakt IDs → sync list)
+5. Dispatches `run_end` with a summary (lists processed, movies/shows added, duration)
+6. Destroys the FlareSolverr session in a `finally` block, so it also covers the early abort paths and thrown errors
+
+Between lists, an abort checkpoint honours `SIGTERM`/`SIGINT` — it stops only after the current Trakt write, never mid-write.
+
+**`src/Scheduler/Scheduler.ts`** - Daemon mode:
+- Runs the pipeline on `node-cron` schedules; `runOnStart` triggers an immediate first run
+- Guards against overlap: a tick is skipped while a run is still in flight
+- `stop()` awaits the in-flight run so a shutdown never truncates a Trakt write
+
+**`src/Notifications/`** - Event dispatch:
+- Three events: `run_start`, `run_end`, `error`, each with its own list of destinations
+- Adapters: webhook, gotify, ntfy, apprise
+- No-throw contract: a failing destination logs a warning and never breaks a run. Logs carry only the destination host, never the full URL, which would leak webhook secrets
 
 **`src/Flixpatrol/FlixPatrol.ts`** - Web scraping:
 - Platform/location constants defined as const arrays (type guards derive from these)
@@ -63,17 +116,20 @@ src/
 - Search: matches titles by name and year
 
 **`src/Utils/GetAndValidateConfigs.ts`** - Configuration validation:
-- Runtime validation of all config properties
-- Exits with `process.exit(1)` on validation errors (no exception handling)
+- Zod schemas validate every config block at load time
+- Throws `ConfigurationError` on invalid config; `app.ts` catches it, dispatches an `error` notification, then exits 1
+- Optional blocks (`FlixPatrolMostHours`, `Notifications`, `Schedule`, `FlareSolverr`) are read through `config.has()` and fall back to their defaults, so an absent block is never an error
 
 ### Key Types
 
 ```typescript
 // FlixPatrol types
-type FlixPatrolTop10Platform = 'netflix' | 'hbo-max' | 'disney' | 'amazon-prime' | ... // 54 platforms
-type FlixPatrolTop10Location = 'world' | 'france' | 'united-states' | ... // 200+ countries
-type FlixPatrolPopularPlatform = 'movie-db' | 'imdb' | 'letterboxd' | ... // 14 sources
+type FlixPatrolTop10Platform = 'netflix' | 'hbo-max' | 'disney' | 'amazon-prime' | ... // 74 platforms
+type FlixPatrolTop10Location = 'world' | 'france' | 'united-states' | ... // 199 locations
+type FlixPatrolPopularPlatform = 'wikipedia' | 'youtube' // 2 sources
 type FlixPatrolConfigType = 'movies' | 'shows' | 'both'
+type FlixPatrolMostHoursPeriod = 'total' | 'first-week' | 'first-month'
+type FlixPatrolMostHoursLanguage = 'all' | 'english' | 'non-english'
 
 // Trakt types
 type TraktTVId = number | null
@@ -118,6 +174,16 @@ File: `config/default.json`
     original?: boolean,  // Netflix originals only
     orderByViews?: boolean  // sort by views instead of hours
   }],
+  FlixPatrolMostHours: [{  // optional block: absent means []
+    enabled: boolean,
+    privacy: TraktPrivacy,
+    limit: number,  // 1-100
+    type: 'movies' | 'shows' | 'both',
+    period: 'total' | 'first-week' | 'first-month',
+    language?: 'all' | 'english' | 'non-english',  // default: 'all'
+    name?: string,
+    normalizeName?: boolean
+  }],
   Trakt: {
     saveFile: string,  // OAuth token file path
     clientId: string,
@@ -128,7 +194,22 @@ File: `config/default.json`
     savePath: string,  // cache directory
     ttl: number  // seconds (default: 604800 = 7 days)
   },
-  FlareSolverr: {
+  Notifications: {  // optional block: absent means {}
+    run_start?: Destination[],
+    run_end?: Destination[],
+    error?: Destination[]
+    // Destination is a discriminated union on `type`:
+    //   { type: 'webhook', url }
+    //   { type: 'gotify',  url, token }
+    //   { type: 'ntfy',    url, topic }
+    //   { type: 'apprise', url, key }
+  },
+  Schedule: {  // optional block: absent means disabled
+    enabled: boolean,  // default: false
+    crons: string[],  // default: []; must be non-empty when enabled
+    runOnStart: boolean  // default: false
+  },
+  FlareSolverr: {  // optional block: absent means disabled
     enabled: boolean,  // default: false
     url?: string,  // mandatory when enabled, e.g. http://localhost:8191/v1
     maxTimeout: number  // default: 60000
@@ -161,9 +242,12 @@ Detail page (title/year extraction):
 
 ### Error Handling
 
-- **Configuration errors**: `logger.error()` + `process.exit(1)`
-- **API/Network errors**: `logger.error()` + `process.exit(1)` or return null
-- **SIGINT**: Graceful shutdown with log message
+Errors derive from `AppError` (`src/Utils/Errors.ts`): `ConfigurationError`, `FlixPatrolError`, `TraktError`, `FlareSolverrError`.
+
+- **Configuration errors**: throw `ConfigurationError`, caught in `app.ts` → `error` notification → exit 1
+- **Scraping failures**: `getFlixPatrolHTMLPage` returns `null` (never throws); callers turn that into `FlixPatrolError`, which fails the run
+- **Notification failures**: logged as warnings only — a broken destination never fails a run
+- **SIGINT / SIGTERM**: graceful. One-shot mode dispatches an `error` notification and exits 130; daemon mode stops the scheduler and awaits the in-flight run. An abort checkpoint between lists stops only after the current Trakt write completes
 
 ### Rate Limiting
 

--- a/README.md
+++ b/README.md
@@ -471,11 +471,11 @@ To run this application you need a Trakt account and a Client ID / Client Secret
 
 ## Supported Platforms
 
-### Top 10 Platforms (72)
+### Top 10 Platforms (74)
 
 `9now`, `abema`, `amazon`, `amazon-channels`, `amazon-prime`, `amc-plus`, `antenna-tv`, `apple-tv`, `bbc`, `canal`, `catchplay`, `cda`, `chili`, `claro-video`, `coupang-play`, `crunchyroll`, `discovery-plus`, `disney`, `francetv`, `friday`, `globoplay`, `go3`, `google`, `hami-video`, `hayu`, `hbo-max`, `hrti`, `hulu`, `hulu-nippon`, `itunes`, `jiocinema`, `jiohotstar`, `joyn`, `lemino`, `m6plus`, `mgm-plus`, `myvideo`, `neon-tv`, `netflix`, `now`, `oneplay`, `osn`, `paramount-plus`, `peacock`, `player`, `pluto-tv`, `raiplay`, `rakuten-tv`, `rtl-plus`, `sbs`, `shahid`, `skyshowtime`, `stan`, `starz`, `streamz`, `telasa`, `tf1`, `tod`, `trueid`, `tubi`, `tv-2-norge`, `u-next`, `viaplay`, `videoland`, `vidio`, `viki`, `viu`, `vix`, `voyo`, `vudu`, `watchit`, `wavve`, `wow`, `zee5`
 
-### Popular Sources (12)
+### Popular Sources (2)
 
 `wikipedia`, `youtube`
 

--- a/config/default.json
+++ b/config/default.json
@@ -17,7 +17,8 @@
       "privacy": "private",
       "limit": 10,
       "name": "Disney Plus Top 10 Shows",
-      "type": "shows"
+      "type": "shows",
+      "normalizeName": false
     },
     {
       "platform": "amazon-prime",
@@ -26,7 +27,8 @@
       "privacy": "private",
       "limit": 10,
       "name": "Amazon Prime Top 10",
-      "type": "both"
+      "type": "both",
+      "normalizeName": false
     },
     {
       "platform": "apple-tv",
@@ -43,6 +45,17 @@
       "privacy": "private",
       "limit": 10,
       "type": "both"
+    },
+    {
+      "platform": "netflix",
+      "location": "united-states",
+      "fallback": false,
+      "privacy": "private",
+      "limit": 10,
+      "name": "Netflix Top 10 Kids",
+      "normalizeName": false,
+      "type": "both",
+      "kids": true
     }
   ],
   "FlixPatrolPopular": [
@@ -61,6 +74,30 @@
       "limit": 50,
       "type": "both",
       "year": 2024
+    }
+  ],
+  "FlixPatrolMostHours": [
+    {
+      "enabled": true,
+      "privacy": "public",
+      "limit": 50,
+      "type": "both",
+      "period": "total"
+    },
+    {
+      "enabled": true,
+      "privacy": "public",
+      "limit": 50,
+      "type": "both",
+      "period": "first-week"
+    },
+    {
+      "enabled": true,
+      "privacy": "public",
+      "limit": 50,
+      "type": "both",
+      "period": "first-month",
+      "language": "english"
     }
   ],
   "Trakt": {

--- a/tests/Utils/defaultConfigConsistency.test.ts
+++ b/tests/Utils/defaultConfigConsistency.test.ts
@@ -1,0 +1,76 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import fs, { readFileSync } from 'fs';
+import { Utils } from '../../src/Utils/Utils';
+
+// Partial mock: only the three calls ensureConfigExist() makes are stubbed, so it
+// generates in memory instead of touching the working tree. Everything else — in
+// particular readFileSync, used below to read the tracked config — stays real.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const stubbed = {
+    ...actual,
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+  return { ...stubbed, default: stubbed };
+});
+
+vi.spyOn(process, 'exit').mockImplementation((() => {
+  throw new Error('process.exit called');
+}) as unknown as typeof process.exit);
+
+/** Recursively sort object keys so the comparison ignores key ordering. */
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.keys(record)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep(record[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+/**
+ * There are two sources of default configuration and they must agree:
+ *
+ *  - `config/default.json`, the version-controlled reference file, used by anyone
+ *    running from a clone of the repository;
+ *  - the `defaultConfig` literal inside `Utils.ensureConfigExist()`, written only
+ *    when `config/default.json` is missing — a fresh install (Docker with an empty
+ *    config volume, or a downloaded binary).
+ *
+ * Nothing in the language keeps them in sync, and they had genuinely drifted:
+ * `FlixPatrolMostHours` and the Kids Top10 entry existed only in the generator,
+ * and two entries were missing `normalizeName: false` — so the same release
+ * produced differently-named Trakt lists depending on how it had been installed.
+ *
+ * This test is the lock. Add a block to one source, add it to the other.
+ */
+describe('default configuration consistency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('config/default.json matches the defaultConfig generated on a fresh install', () => {
+    vi.mocked(fs.existsSync)
+      .mockReturnValueOnce(false) // config/default.json is missing
+      .mockReturnValueOnce(true); // the config directory already exists
+
+    expect(() => Utils.ensureConfigExist()).toThrow('process.exit called');
+
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    const generated: unknown = JSON.parse(written);
+    const tracked: unknown = JSON.parse(readFileSync('config/default.json', 'utf8'));
+
+    expect(sortKeysDeep(generated)).toEqual(sortKeysDeep(tracked));
+  });
+});


### PR DESCRIPTION
## Description

Documentation and default-configuration consistency cleanup. No behaviour change to the scraping or sync logic.

### `config/default.json` diverged from the fresh-install generator

There are two sources of default configuration, and nothing kept them in sync:

- `config/default.json`, the version-controlled reference, used when running from a clone;
- the `defaultConfig` literal in `Utils.ensureConfigExist()`, written only when `config/default.json` is missing — a fresh install (Docker with an empty config volume, or a downloaded binary).

They had drifted in three ways:

| Drift | Effect |
|---|---|
| `FlixPatrolMostHours` present only in the generator | 3 lists exist or not depending on how you installed |
| Kids Top10 entry present only in the generator | 1 list exists or not depending on how you installed |
| `normalizeName: false` missing on 2 entries in `default.json` | **different Trakt list names** — `disney-plus-top-10-shows` instead of `Disney Plus Top 10 Shows` |

The third was the subtle one: same release, same platforms, but differently-named Trakt lists depending on the install path.

Both sources are now byte-identical in content, and **`tests/Utils/defaultConfigConsistency.test.ts` locks it** — it parses the generator's output and the tracked file and compares them ignoring key order. Verified it actually fails on a divergence (changed one value artificially → red; restored → green), because a consistency test that never breaks is worthless.

### `CLAUDE.md` was substantially stale

The module tree omitted four whole modules: `Pipeline/`, `Scheduler/`, `Notifications/`, `types/`. Also added or corrected:

- the real `app.ts` flow, including the one-shot vs daemon branch and why the `NotificationManager` is built before config loading
- `runPipeline`, `Scheduler` and `Notifications` documented as components
- the three previously undocumented config blocks: `FlixPatrolMostHours`, `Notifications`, `Schedule`
- **the test commands, which were entirely missing** despite the project having 254 tests
- the environment variables (`LOG_LEVEL`, `DRY_RUN`, `LIST_NAME_PREFIX`)
- Error Handling: it still described a bare `logger.error()` + `process.exit(1)`, whereas the code throws typed `AppError` subclasses that `app.ts` turns into an `error` notification

Stale counts fixed against the actual unions: `54 platforms` → **74**, `200+ countries` → **199**, `14 sources` → **2**.

### `README.md` counts

Section titles said `Top 10 Platforms (72)` and `Popular Sources (12)`; the real values are **74** and **2**. The lists themselves were accurate — verified all 74 platforms are present, none missing.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Dependencies update

The "bug fix" box covers the `config/default.json` divergence: it produced genuinely different list names between install paths.

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

**254 tests passing** (253 + the new consistency lock), `tsc --noEmit` and `eslint` clean.

## Note for reviewers

`FlixPatrolMostHours` is aligned at `enabled: true`, matching the generator and consistent with `FlixPatrolMostWatched`. Anyone whose local config inherits the tracked `default.json` without overriding this block will get those 3 public lists created on the next run. This was a deliberate call: the alternative — aligning both sources at `false` — would have silently changed what a fresh install produces.

Two related gaps found while doing this, both out of scope and worth their own issues:

- `tsconfig.json` lists `"tests"` in `exclude`, so **no test file is type-checked**; `tsc --noEmit` passes while ignoring all 16 test files.
- `vitest.config.ts` nests coverage thresholds under `thresholds.global`, which Vitest treats as a glob matching no files — so **no threshold is enforced**. Actual coverage is 72.4% lines / 67.3% branches against a declared 80.

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
