### PR TITLE
fix(tests): type-check test files through a dedicated tsconfig

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 - [ ] I have added/updated tests if needed
 - [ ] Code coverage is maintained or improved
 - [ ] Lint passes (`npm run lint`)
+- [ ] Type-check passes (`npm run typecheck`)
 - [ ] Tests pass (`npm test`)
 
 ## Related Issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      # The Build job only type-checks src/; this covers tests/, which the base
+      # tsconfig excludes.
+      - name: Type-check
+        run: npm run typecheck
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,24 @@ npm run test:coverage # Run tests with coverage (reports in .reports/coverage)
 npm run test:e2e     # Opt-in end-to-end suites against real services (see Testing below)
 npm run lint         # Run ESLint
 npm run lint-and-fix # Run ESLint with auto-fix
+npm run typecheck    # Type-check src/ AND tests/ (see Testing below)
 npm run package      # Create cross-platform binaries in bin/
 ```
 
 ### Testing
+
+**Type-checking the tests**: `tsconfig.json` excludes `tests`, because its `rootDir: "src"` and
+emit settings describe the shipped build only. `npm run typecheck` runs the separate
+`tsconfig.test.json`, which covers `src/`, `tests/`, `types/` and the vitest configs with
+`noEmit`. It overrides `target`/`module`/`moduleResolution` to match how vitest actually loads
+test files (ESM, Vite resolution) — under the base `commonjs`/`es2016`, every top-level `await` in
+a test raises a TS1378 that is a pure false positive. The **`Lint` CI job** runs it; the `Build`
+job type-checks `src/` only, through the real `tsc` emit. Do not "simplify" this by dropping
+`tests` from the base `exclude`: that reintroduces TS6059 on every test file.
+
+Test helpers live in `tests/helpers/` and are not test files — `mockProcessExit()` is there
+because `process.exit` returns `never`, which no mock implementation satisfies without a cast, and
+that cast belongs in one place.
 
 Two vitest configurations, deliberately separate:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,9 @@ npm run lint
 # Lint and auto-fix
 npm run lint-and-fix
 
+# Type-check src/ and tests/ (see Type checking below)
+npm run typecheck
+
 # Run the unit and integration suites once
 npm test
 
@@ -59,10 +62,31 @@ npm run package
 
 ## Code style
 
-ESLint is the single source of truth (`eslint.config.mjs`): the TypeScript recommended rule sets
-plus `max-len` at **120** characters, with strings and template literals exempt. `npm run lint`
-must pass before a pull request is merged, and `npm run lint-and-fix` handles most of the
-mechanical work.
+ESLint is the single source of truth for style (`eslint.config.mjs`): the TypeScript recommended
+rule sets plus `max-len` at **120** characters, with strings and template literals exempt.
+`npm run lint` must pass before a pull request is merged, and `npm run lint-and-fix` handles most
+of the mechanical work.
+
+## Type checking
+
+There are two TypeScript projects, and both are gates:
+
+- `tsconfig.json` describes the **shipped build** — `rootDir: "src"`, emit to `build/`. It is what
+  `npm run build` and the `Build` CI job compile, and it excludes `tests`.
+- `tsconfig.test.json` extends it and covers what the build has no business compiling: `tests/`,
+  `types/` and the vitest configs, with `noEmit`. `npm run typecheck` runs it, and so does the
+  `Lint` CI job.
+
+Run `npm run typecheck` before opening a pull request. Test files are where mocks cast freely and
+reach into private shapes, so a test that has drifted from the signature it is meant to protect
+only shows up here.
+
+The overrides in `tsconfig.test.json` are load-bearing. `rootDir: "."` is what keeps `TS6059`
+("not under rootDir") off every test file, and `target`/`module`/`moduleResolution` are set to
+match how vitest actually loads tests — ESM with Vite resolution — because under the base
+`commonjs`/`es2016` every top-level `await` in a test raises a `TS1378` that is a pure false
+positive. Do **not** collapse the two projects by dropping `tests` from the base `exclude`: that
+is the obvious-looking fix and it reintroduces 34 `TS6059` errors.
 
 ## Tests
 
@@ -72,6 +96,11 @@ branches and statements. `src/app.ts` is deliberately excluded from coverage: it
 process-level wiring (signal handlers, `process.exit` paths), so testing it would assert on the
 process lifecycle rather than on behaviour — the logic it orchestrates is covered through
 `Pipeline/` and `Scheduler/`.
+
+Shared test helpers live in `tests/helpers/`, which the vitest `include` pattern does not match, so
+nothing there is collected as a suite. Reach for it when a mock needs a cast to type-check —
+`mockProcessExit()` exists because `process.exit` returns `never`, which no mock implementation can
+satisfy, and that cast is worth writing once rather than per file.
 
 ## End-to-end tests
 
@@ -198,7 +227,7 @@ Branch off `develop` and open the pull request against `develop`.
 
 Fill in [the pull request template](.github/PULL_REQUEST_TEMPLATE.md) — description, type of
 change, the checklist (local testing, tests added or updated, coverage maintained,
-`npm run lint` passing, `npm test` passing) and any related issues.
+`npm run lint`, `npm run typecheck` and `npm test` passing) and any related issues.
 
 Add the labels that apply:
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start:dev": "nodemon",
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
+    "typecheck": "tsc -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/tests/Flixpatrol/FlixPatrol.test.ts
+++ b/tests/Flixpatrol/FlixPatrol.test.ts
@@ -1370,7 +1370,7 @@ describe('FlixPatrol', () => {
         country: 'france',
       };
 
-      const result = await flixpatrol.getMostWatched('Movies', config);
+      await flixpatrol.getMostWatched('Movies', config);
 
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('-from-france'));
     });
@@ -1420,7 +1420,7 @@ describe('FlixPatrol', () => {
         premiere: 2023,
       };
 
-      const result = await flixpatrol.getMostWatched('Movies', config);
+      await flixpatrol.getMostWatched('Movies', config);
 
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('-2023'));
     });
@@ -1470,7 +1470,7 @@ describe('FlixPatrol', () => {
         orderByViews: true,
       };
 
-      const result = await flixpatrol.getMostWatched('Movies', config);
+      await flixpatrol.getMostWatched('Movies', config);
 
       expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('/by-views'));
     });

--- a/tests/Targets/ResolutionCache.test.ts
+++ b/tests/Targets/ResolutionCache.test.ts
@@ -4,7 +4,9 @@ import {
 
 const cacheGet = vi.fn();
 const cacheSet = vi.fn();
-const cacheFactory = vi.fn(() => ({ get: cacheGet, set: cacheSet }));
+const cacheFactory = vi.fn<(...args: unknown[]) => { get: typeof cacheGet; set: typeof cacheSet }>(
+  () => ({ get: cacheGet, set: cacheSet }),
+);
 
 vi.mock('file-system-cache', () => ({
   default: (...args: unknown[]) => cacheFactory(...args),

--- a/tests/Utils/Utils.test.ts
+++ b/tests/Utils/Utils.test.ts
@@ -4,6 +4,7 @@ import { logger } from '../../src/Utils/Logger';
 import { TRAKT_TEMPLATE_CLIENT_ID, TRAKT_TEMPLATE_CLIENT_SECRET } from '../../src/types';
 import fs from 'fs';
 import path from 'path';
+import { mockProcessExit } from '../helpers/mockProcessExit';
 
 vi.mock('fs', () => ({
   default: {
@@ -15,9 +16,7 @@ vi.mock('fs', () => ({
   },
 }));
 
-const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
-  throw new Error('process.exit called');
-}) as unknown as (code?: number) => never);
+const mockExit = mockProcessExit();
 
 describe('Utils', () => {
   beforeEach(() => {
@@ -39,7 +38,6 @@ describe('Utils', () => {
     });
 
     it('should resolve after the specified time', async () => {
-      const startTime = Date.now();
       const sleepPromise = Utils.sleep(1000);
 
       vi.advanceTimersByTime(1000);
@@ -243,7 +241,7 @@ describe('Utils', () => {
       Utils.warnAboutOrphanedCaches('./config/.cache');
 
       expect(warn).toHaveBeenCalledTimes(1);
-      const message = warn.mock.calls[0][0] as string;
+      const message = warn.mock.calls[0][0] as unknown as string;
       expect(message).toContain(path.join('./config/.cache', 'movies'));
       expect(message).toContain(path.join('./config/.cache', 'tv-shows'));
       expect(message).toMatch(/no longer read/);
@@ -258,7 +256,7 @@ describe('Utils', () => {
       Utils.warnAboutOrphanedCaches('./config/.cache');
 
       expect(warn).toHaveBeenCalledTimes(1);
-      const message = warn.mock.calls[0][0] as string;
+      const message = warn.mock.calls[0][0] as unknown as string;
       expect(message).toContain(path.join('./config/.cache', 'tv-shows'));
       expect(message).not.toContain(path.join('./config/.cache', 'movies'));
       warn.mockRestore();

--- a/tests/Utils/defaultConfigConsistency.test.ts
+++ b/tests/Utils/defaultConfigConsistency.test.ts
@@ -4,6 +4,7 @@ import {
 import fs, { readFileSync } from 'fs';
 import { Utils } from '../../src/Utils/Utils';
 import { TRAKT_TEMPLATE_CLIENT_ID, TRAKT_TEMPLATE_CLIENT_SECRET } from '../../src/types';
+import { mockProcessExit } from '../helpers/mockProcessExit';
 
 // Partial mock: only the three calls ensureConfigExist() makes are stubbed, so it
 // generates in memory. readFileSync stays real, to read the tracked config below.
@@ -18,9 +19,7 @@ vi.mock('fs', async (importOriginal) => {
   return { ...stubbed, default: stubbed };
 });
 
-vi.spyOn(process, 'exit').mockImplementation((() => {
-  throw new Error('process.exit called');
-}) as unknown as typeof process.exit);
+mockProcessExit();
 
 /** Recursively sort object keys so the comparison ignores key ordering. */
 function sortKeysDeep(value: unknown): unknown {

--- a/tests/helpers/mockProcessExit.ts
+++ b/tests/helpers/mockProcessExit.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest';
+
+export const PROCESS_EXIT_ERROR = 'process.exit called';
+
+/**
+ * Spies on `process.exit` so it throws instead of killing the test run.
+ * The cast lives here once: `process.exit` returns `never`, which no mock
+ * implementation can satisfy on its own.
+ */
+export function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error(PROCESS_EXIT_ERROR);
+  }) as unknown as typeof process.exit);
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,23 @@
+{
+  // Type-checks what the base config leaves out: the test suites and the vitest
+  // configs. A separate project because those files are not part of the shipped
+  // build, which `rootDir: "src"` and the emit settings describe.
+  // `module`/`moduleResolution` follow how vitest actually loads the tests (ESM,
+  // Vite resolution), so top-level await is legal instead of a TS1378 false positive.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": [
+    "src/**/*.ts",
+    "types/**/*.d.ts",
+    "tests/**/*.ts",
+    "vitest.config.ts",
+    "vitest.e2e.config.ts"
+  ],
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
## Description

`tsconfig.json` lists `"tests"` in its `exclude`, so no test file was ever type-checked: `npx tsc --noEmit` passed while ignoring all of them. This adds a dedicated project that covers them, fixes the errors it surfaces, and wires it into CI.

### Why a separate `tsconfig.test.json`, and not just removing `"tests"` from `exclude`

The approach suggested in #524 does not work as-is. The base config has `rootDir: "src"`, so pulling `tests/` into it produces **34 `TS6059` errors** ("not under rootDir") before type-checking anything real. Hence a second project extending the base, with three overrides:

- `rootDir: "."` — removes the `TS6059` noise.
- `target: es2022`, `module: esnext`, `moduleResolution: bundler` — matches how vitest actually loads test files. Under the base `commonjs`/`es2016`, the top-level `await` in `ResolutionCache.test.ts` and `TraktTarget.test.ts` raises a `TS1378` that is a pure false positive.
- an explicit `include` that brings back `types/trakt.d.ts`. Without it, `trakt.tv` raises `TS7016` four times — including inside `src/Trakt/TraktAPI.ts`, because the base config has no `include` and was picking that declaration up through its default `**/*` pattern.

`noEmit` throughout: the `Build` job keeps type-checking `src/` through the real `tsc` emit, this one only checks.

### Errors fixed (8)

| File | Error | Fix |
|---|---|---|
| `tests/Utils/Utils.test.ts:18` | `TS2345` — `process.exit` spy implementation not assignable | shared `tests/helpers/mockProcessExit.ts` |
| `tests/Utils/defaultConfigConsistency.test.ts:21` | (cast was correct, but duplicated) | same helper |
| `tests/Utils/Utils.test.ts:42` | `TS6133` — `startTime` never read | removed (the test uses fake timers, the variable was dead) |
| `tests/Utils/Utils.test.ts:244,259` | `TS2352` — `object` to `string` | `as unknown as string` |
| `tests/Flixpatrol/FlixPatrol.test.ts:1373,1423,1473` | `TS6133` — `result` never read | dropped the binding, kept the `await`: those three tests assert on the fetched URL, not on the return value |
| `tests/Targets/ResolutionCache.test.ts:10` | `TS2556` — spread argument | typed the mock signature via `vi.fn<(...args: unknown[]) => …>()` |

The `process.exit` cast is the one that recurred across files, so it now lives in one typed helper as the issue suggested. `tests/helpers/` is not matched by the vitest `include` pattern, so it is not collected as a suite.

### CI

`npm run typecheck` is added to the **`Lint`** job — static checks, no build needed. Verified the gate actually fails: injecting a deliberate type error into a test file makes it exit `2`, and removing it returns to `0`. Worth stating explicitly given #523 was a quality gate that was declared but inert.

### Docs

`CONTRIBUTING.md` gains a **Type checking** section — the two projects, which one is which gate, and why the overrides are load-bearing — plus `npm run typecheck` in the command list, a note on `tests/helpers/`, and the softening of "ESLint is the single source of truth" to "the single source of truth *for style*", which is no longer the whole story. The PR template gains a `npm run typecheck` checklist line, and `CLAUDE.md` carries the same explanation for future work in the repo. `README.md` needs nothing: it already delegates contributor topics to `CONTRIBUTING.md`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

Local results: `npm run typecheck` exit 0 · `npm run lint` exit 0 · `npm test` 487 tests / 27 files pass · `npm run build` exit 0. No production code changed, so coverage is unaffected.

## Related Issues

Fixes #524
