### PR TITLE
feat(flaresolverr): add optional disableMedia to skip images, CSS and fonts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ Between lists, an abort checkpoint honours `SIGTERM`/`SIGINT` — it stops only 
 **`src/Flixpatrol/FlixPatrol.ts`** - Web scraping:
 - Platform/location constants defined as const arrays (type guards derive from these)
 - Uses `impit` (Chrome impersonation) for direct HTTP requests, or an optional FlareSolverr client when configured. The impit path retries up to 3 times with 1s/2s/4s backoff on 408/429/500/502/503/504, and reports Cloudflare's `cf-mitigated` header when present — that header is what separates "FlixPatrol is down" from "we got bot-blocked". The FlareSolverr path has **no** retry loop: FlareSolverr retries internally, and wrapping a 12s challenge solve in a 3x backoff produces pathological runtimes
+- `FlareSolverr.disableMedia` is forwarded on `request.get` **only when true**, never as an explicit `false`. FlareSolverr lets the request parameter override its own `DISABLE_MEDIA` env var, so sending `false` would silently defeat an operator who enabled it on the container; our default means "no opinion", not "off". It is never sent on `sessions.create`, which does not read it — the measurement in #525 confirmed session creation is unaffected. Effect: ~17% off warm requests, challenge solve unchanged, no solve failures over 80 requests. The saving lands mostly on cold-cache runs, since detail pages are cached for `Cache.ttl`
 - HTML parsing via JSDOM with XPath expressions
 - Returns `MediaItem[]` (title + year) and knows nothing about any backend. The Top10 `fallback` triggers when the *page* yields no result at all, no longer when no backend id could be resolved (behaviour change vs 2.17): a title FlixPatrol lists but the backend does not know is now reported as unmatched instead of silently swapping the whole list for another location's
 - File-system caching with `file-system-cache` (SHA1 keys, TTL-based) under `<Cache.savePath>/details`. The second level, `<Cache.savePath>/resolution-<backend>`, lives in `src/Targets/ResolutionCache.ts`. The 2.x `movies/` and `tv-shows/` directories are orphaned; `Utils.warnAboutOrphanedCaches()` names them once at startup and never deletes them
@@ -353,7 +354,8 @@ File: `config/default.json`
   FlareSolverr: {  // optional block: absent means disabled
     enabled: boolean,  // default: false
     url?: string,  // mandatory when enabled, e.g. http://localhost:8191/v1
-    maxTimeout: number  // default: 60000
+    maxTimeout: number,  // default: 60000
+    disableMedia: boolean  // default: false; blocks images/CSS/fonts in the solver browser
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -460,13 +460,25 @@ tool behaves exactly as before and never contacts FlareSolverr.
 
 | Name       | Description                                    | Mandatory        | Values                    | Default |
 |------------|------------------------------------------------|------------------|---------------------------|---------|
-| enabled    | Route FlixPatrol requests through FlareSolverr  | No               | true, false               | false   |
-| url        | FlareSolverr v1 API endpoint                    | If enabled       | Any valid URL             |         |
-| maxTimeout | Challenge solving timeout in milliseconds       | No               | Number                    | 60000   |
+| enabled      | Route FlixPatrol requests through FlareSolverr | No               | true, false               | false   |
+| url          | FlareSolverr v1 API endpoint                   | If enabled       | Any valid URL             |         |
+| maxTimeout   | Challenge solving timeout in milliseconds      | No               | Number                    | 60000   |
+| disableMedia | Skip images, CSS and fonts while scraping      | No               | true, false               | false   |
 
 When enabled, a browser session is created once at the start of each run and
 destroyed at the end. The first request solves the challenge (around 12s); later
 requests reuse the session and take 1-3s each.
+
+`disableMedia` makes the solver's browser skip images, stylesheets and fonts, which
+the scraper never looks at — it only reads HTML. Measured over 80 requests, it takes
+about **15% off those later requests** and leaves the initial challenge solve
+unchanged, since the challenge is what dominates and it still runs its JavaScript
+normally. Two things temper it: most of the saving lands on **cold-cache runs**,
+because detail pages are cached for `Cache.ttl` and never reach FlareSolverr twice;
+and a browser that fetches no stylesheet at all is a slightly unusual traffic shape,
+which Cloudflare could in principle score. Zero solve failures were observed either
+way, but the default stays `false` so nothing changes for existing setups. It also
+lowers the container's memory and CPU use, which the FlareSolverr docs warn about.
 
 Run FlareSolverr alongside the tool:
 
@@ -599,7 +611,8 @@ instead of localhost: `"url": "http://flaresolverr:8191/v1"`.
   "FlareSolverr": {
     "enabled": false,
     "url": "http://localhost:8191/v1",
-    "maxTimeout": 60000
+    "maxTimeout": 60000,
+    "disableMedia": false
   }
 }
 ```

--- a/config/default.json
+++ b/config/default.json
@@ -124,6 +124,7 @@
   "FlareSolverr": {
     "enabled": false,
     "url": "http://localhost:8191/v1",
-    "maxTimeout": 60000
+    "maxTimeout": 60000,
+    "disableMedia": false
   }
 }

--- a/src/FlareSolverr/FlareSolverrClient.ts
+++ b/src/FlareSolverr/FlareSolverrClient.ts
@@ -32,6 +32,8 @@ export class FlareSolverrClient {
 
   private readonly maxTimeout: number;
 
+  private readonly disableMedia: boolean;
+
   private sessionId: string | null = null;
 
   constructor(options: FlareSolverrOptions) {
@@ -40,6 +42,7 @@ export class FlareSolverrClient {
     }
     this.endpoint = options.url;
     this.maxTimeout = options.maxTimeout;
+    this.disableMedia = options.disableMedia;
   }
 
   private async command(payload: Record<string, unknown>): Promise<FlareSolverrEnvelope> {
@@ -100,6 +103,10 @@ export class FlareSolverrClient {
           url,
           session: this.sessionId ?? SESSION_NAME,
           maxTimeout: this.maxTimeout,
+          // Sent only when true: FlareSolverr lets the request parameter override its
+          // own DISABLE_MEDIA env var, so sending `false` would silently defeat an
+          // operator who enabled it on the container.
+          ...(this.disableMedia ? { disableMedia: true } : {}),
         });
 
         if (envelope.status !== 'ok') {

--- a/src/Utils/Utils.ts
+++ b/src/Utils/Utils.ts
@@ -177,6 +177,7 @@ export class Utils {
           enabled: false,
           url: 'http://localhost:8191/v1',
           maxTimeout: 60000,
+          disableMedia: false,
         },
       };
 

--- a/src/types/Config.types.ts
+++ b/src/types/Config.types.ts
@@ -209,6 +209,9 @@ export const FlareSolverrOptionsSchema = z.object({
   enabled: z.boolean().default(false),
   url: z.url().optional(),
   maxTimeout: z.number().default(60000),
+  // Blocks images, CSS and fonts in the solver's browser. Measured at ~17% off warm
+  // requests with no effect on the challenge solve — see issue #525.
+  disableMedia: z.boolean().default(false),
 }).refine(
   (f) => !f.enabled || (f.url !== undefined && f.url.length > 0),
   { message: 'url must be set when enabled' },

--- a/tests/FlareSolverr/FlareSolverrClient.test.ts
+++ b/tests/FlareSolverr/FlareSolverrClient.test.ts
@@ -35,7 +35,7 @@ describe('FlareSolverrClient', () => {
   beforeEach(() => {
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
-    client = new FlareSolverrClient({ enabled: true, url: ENDPOINT, maxTimeout: 60000 });
+    client = new FlareSolverrClient({ enabled: true, url: ENDPOINT, maxTimeout: 60000, disableMedia: false });
   });
 
   afterEach(() => {
@@ -117,7 +117,9 @@ describe('FlareSolverrClient', () => {
     });
 
     it('forwards a custom maxTimeout from config', async () => {
-      const custom = new FlareSolverrClient({ enabled: true, url: ENDPOINT, maxTimeout: 90000 });
+      const custom = new FlareSolverrClient({
+        enabled: true, url: ENDPOINT, maxTimeout: 90000, disableMedia: false,
+      });
       fetchMock.mockResolvedValueOnce(jsonResponse(okSession));
       fetchMock.mockResolvedValueOnce(jsonResponse(okSolution('<html></html>')));
       await custom.createSession();
@@ -125,6 +127,40 @@ describe('FlareSolverrClient', () => {
       await custom.get('https://flixpatrol.com/a');
 
       expect(payloadOf(fetchMock, 1).maxTimeout).toBe(90000);
+    });
+
+    it('omits disableMedia from the payload when the option is false', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(okSession));
+      fetchMock.mockResolvedValueOnce(jsonResponse(okSolution('<html></html>')));
+      await client.createSession();
+
+      await client.get('https://flixpatrol.com/a');
+
+      expect(payloadOf(fetchMock, 1)).not.toHaveProperty('disableMedia');
+    });
+
+    it('sends disableMedia: true when the option is enabled', async () => {
+      const noMedia = new FlareSolverrClient({
+        enabled: true, url: ENDPOINT, maxTimeout: 60000, disableMedia: true,
+      });
+      fetchMock.mockResolvedValueOnce(jsonResponse(okSession));
+      fetchMock.mockResolvedValueOnce(jsonResponse(okSolution('<html></html>')));
+      await noMedia.createSession();
+
+      await noMedia.get('https://flixpatrol.com/a');
+
+      expect(payloadOf(fetchMock, 1).disableMedia).toBe(true);
+    });
+
+    it('never sends disableMedia on sessions.create, which does not accept it', async () => {
+      const noMedia = new FlareSolverrClient({
+        enabled: true, url: ENDPOINT, maxTimeout: 60000, disableMedia: true,
+      });
+      fetchMock.mockResolvedValueOnce(jsonResponse(okSession));
+
+      await noMedia.createSession();
+
+      expect(payloadOf(fetchMock, 0)).not.toHaveProperty('disableMedia');
     });
 
     it('retries an error envelope and returns null after exhausting all attempts', async () => {
@@ -262,7 +298,7 @@ describe('FlareSolverrClient', () => {
   });
 
   it('rejects construction without a url', () => {
-    expect(() => new FlareSolverrClient({ enabled: true, maxTimeout: 60000 }))
+    expect(() => new FlareSolverrClient({ enabled: true, maxTimeout: 60000, disableMedia: false }))
       .toThrow(FlareSolverrError);
   });
 });

--- a/tests/Pipeline/runPipeline.test.ts
+++ b/tests/Pipeline/runPipeline.test.ts
@@ -325,7 +325,7 @@ describe('runPipeline FlareSolverr lifecycle', () => {
 
   it('does not create a session when disabled', async () => {
     await runPipeline(baseDeps({
-      flareSolverrOptions: { enabled: false, maxTimeout: 60000 },
+      flareSolverrOptions: { enabled: false, maxTimeout: 60000, disableMedia: false },
     }));
 
     expect(createSession).not.toHaveBeenCalled();
@@ -333,7 +333,7 @@ describe('runPipeline FlareSolverr lifecycle', () => {
 
   it('creates and destroys the session when enabled', async () => {
     await runPipeline(baseDeps({
-      flareSolverrOptions: { enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 60000 },
+      flareSolverrOptions: { enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 60000, disableMedia: false },
     }));
 
     expect(createSession).toHaveBeenCalledOnce();
@@ -344,7 +344,7 @@ describe('runPipeline FlareSolverr lifecycle', () => {
     getTop10Sections.mockRejectedValueOnce(new Error('scrape exploded'));
 
     await expect(runPipeline(baseDeps({
-      flareSolverrOptions: { enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 60000 },
+      flareSolverrOptions: { enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 60000, disableMedia: false },
       flixPatrolTop10: top10Config,
     }))).rejects.toThrow('scrape exploded');
 

--- a/tests/Utils/GetAndValidateConfigs.test.ts
+++ b/tests/Utils/GetAndValidateConfigs.test.ts
@@ -414,14 +414,14 @@ describe('GetAndValidateConfigs', () => {
       it('returns disabled defaults when the FlareSolverr block is absent', () => {
         vi.mocked(config.has).mockReturnValue(false);
         const result = GetAndValidateConfigs.getFlareSolverrOptions();
-        expect(result).toEqual({ enabled: false, maxTimeout: 60000 });
+        expect(result).toEqual({ enabled: false, maxTimeout: 60000, disableMedia: false });
       });
 
       it('returns disabled defaults without error when present but disabled', () => {
         vi.mocked(config.has).mockReturnValue(true);
         vi.mocked(config.get).mockReturnValue({ enabled: false });
         const result = GetAndValidateConfigs.getFlareSolverrOptions();
-        expect(result).toEqual({ enabled: false, maxTimeout: 60000 });
+        expect(result).toEqual({ enabled: false, maxTimeout: 60000, disableMedia: false });
       });
 
       it('returns a valid enabled configuration', () => {
@@ -431,7 +431,7 @@ describe('GetAndValidateConfigs', () => {
         });
         const result = GetAndValidateConfigs.getFlareSolverrOptions();
         expect(result).toEqual({
-          enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 90000,
+          enabled: true, url: 'http://localhost:8191/v1', maxTimeout: 90000, disableMedia: false,
         });
       });
 
@@ -440,6 +440,22 @@ describe('GetAndValidateConfigs', () => {
         vi.mocked(config.get).mockReturnValue({ enabled: true, url: 'http://localhost:8191/v1' });
         const result = GetAndValidateConfigs.getFlareSolverrOptions();
         expect(result.maxTimeout).toBe(60000);
+      });
+
+      it('defaults disableMedia to false when omitted', () => {
+        vi.mocked(config.has).mockReturnValue(true);
+        vi.mocked(config.get).mockReturnValue({ enabled: true, url: 'http://localhost:8191/v1' });
+        const result = GetAndValidateConfigs.getFlareSolverrOptions();
+        expect(result.disableMedia).toBe(false);
+      });
+
+      it('carries disableMedia through when set', () => {
+        vi.mocked(config.has).mockReturnValue(true);
+        vi.mocked(config.get).mockReturnValue({
+          enabled: true, url: 'http://localhost:8191/v1', disableMedia: true,
+        });
+        const result = GetAndValidateConfigs.getFlareSolverrOptions();
+        expect(result.disableMedia).toBe(true);
       });
 
       it('throws when enabled with no url', () => {

--- a/tests/Utils/Utils.test.ts
+++ b/tests/Utils/Utils.test.ts
@@ -214,6 +214,7 @@ describe('Utils', () => {
         enabled: false,
         url: 'http://localhost:8191/v1',
         maxTimeout: 60000,
+        disableMedia: false,
       });
       expect(mockExit).toHaveBeenCalledWith(0);
     });

--- a/tests/e2e/FlixPatrolXPath.e2e.test.ts
+++ b/tests/e2e/FlixPatrolXPath.e2e.test.ts
@@ -504,7 +504,9 @@ describe.skipIf(!process.env.E2E_FLARESOLVERR_URL)('FlixPatrol XPath drift (E2E)
   };
 
   beforeAll(async () => {
-    client = new FlareSolverrClient({ enabled: true, url: flareSolverrUrl, maxTimeout: 60000 });
+    client = new FlareSolverrClient({
+      enabled: true, url: flareSolverrUrl, maxTimeout: 60000, disableMedia: false,
+    });
     await client.createSession();
 
     for (const path of LISTING_PATHS) {


### PR DESCRIPTION
## Description

Exposes FlareSolverr's `disableMedia` as an optional key on the `FlareSolverr` config block, default `false`. It makes the solver's browser skip images, stylesheets and fonts — none of which the scraper reads, since it only runs XPath over HTML.

Implements #525 after measuring it, as that issue insisted. The full numbers and protocol are [in the issue](https://github.com/Navino16/flixpatrol-top10-on-trakt/issues/525); the short version, over 8 alternating A/B pairs and 80 warm requests:

|                    | `false` | `true` | delta |
|---|---|---|---|
| challenge solve    | 11.53s | 11.47s | — |
| **warm median**    | **0.84s** | **0.70s** | **−16.8%** |
| warm p90           | 1.41s | 1.13s | −19.9% |
| **solve failures** | **0 / 8** | **0 / 8** | none |

The `true` arm had the lower median in 8 of 8 pairs (sign test, p ≈ 0.008), so this is not two noisy series. **The ~30% hypothesised in the issue does not materialise** — the challenge solve is untouched and it dominates, so the real figure is ~17% of warm-request cost, and mostly on cold-cache runs since detail pages are cached for `Cache.ttl`. The docs say 15%, not 30%.

### Two design decisions worth reviewing

**`disableMedia` is sent only when `true`, never as an explicit `false`.** FlareSolverr lets the request parameter override its own `DISABLE_MEDIA` env var (`flaresolverr_service.py:342-345`). Sending `false` on every request would silently defeat an operator who enabled it on the container, so our default means "no opinion" rather than "off". There is a test pinning that the key is absent from the payload when the option is false.

**It is never sent on `sessions.create`**, which does not read it — the parameter is consumed in `_evil_logic`, on the `request.get`/`request.post` path. The measurement confirms it: session creation timing is identical across both arms. Also pinned by a test.

### On the risk the issue raised

The issue worried that `disableMedia` might starve the Cloudflare challenge. Reading the running container, the implementation is a CDP `Network.setBlockedURLs` over a glob list of file extensions — images, `*.css`, fonts. **`*.js` is not in it**, and the challenge's own endpoints (`/cdn-cgi/challenge-platform/...`) carry no extension, so nothing blocks them. The residual risk is narrower: a browser that never fetches a stylesheet is an unusual traffic shape that Cloudflare could in principle score. 8 solves per arm cannot rule that out, which is exactly why the default is `false`.

Verified end to end against a real FlareSolverr 3.5.0 with the built client and `disableMedia: true`: challenge solved in 11.03s, 242KB of HTML returned, Top 10 markup present.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Dependencies update

Not a breaking change: the key defaults to `false`, and an existing config that omits it keeps today's behaviour exactly.

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

5 tests added (payload omission, payload presence, `sessions.create` exclusion, schema default, schema passthrough). **492 tests pass**, up from 487. Coverage 93.62% statements / 87.23% branches, above the 80% gate. Also updated the four test fixtures that build a `FlareSolverrOptions` — the type-check gate from #524 caught every one of them, which is a pleasant first outing for it.

## Related Issues

Closes #525
