### PR TITLE
fix(deps): bump transitive undici and nanoid to clear audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4502,9 +4502,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5842,9 +5842,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description

`npm audit fix` on `develop`, clearing the last 2 high-severity advisories. **Only `package-lock.json` changes** — 6 lines, two transitive bumps, no `package.json` edit and no production code touched.

| Package | Change | Scope | Advisories |
|---|---|---|---|
| `undici` | 7.28.0 → 7.29.0 | **dev**, via `@yao-pkg/pkg → pkg-fetch` | [5 advisories](https://github.com/advisories/GHSA-8xcm-r25x-g524) (retry interceptor desync, cache directive disclosure, CRLF via blob body, cookie injection) |
| `nanoid` | 3.3.16 → 3.3.18 | **dev**, via `vitest → vite → postcss` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — infinite loop on `size: 0` with custom generators |

`npm audit` goes from **2 high** to **0 vulnerabilities**.

### Why the production side was already covered

Worth recording, because the undici picture is easy to misread — the copy hoisted to `node_modules/undici` is **not** the one production uses:

- `jsdom@30.0.1` (production, merged in #526) resolves its own nested `undici@8.10.0`, which is outside the vulnerable `7.0.0 - 7.28.0` range. So #526 already fixed the production exposure.
- The `undici@7.28.0` that `npm audit` kept flagging was reachable only through `@yao-pkg/pkg`, a **devDependency** used to build the release binaries. `npm ls undici --omit=dev` confirms the only production path is `jsdom → undici@8.10.0`.

Both flagged packages are therefore dev-only after #526, which is why this is a lockfile hygiene fix rather than an urgent patch. It is still worth doing: two permanent high-severity lines in the audit report are the ideal camouflage for a real one arriving later.

Exploitability was nil in both cases regardless — `nanoid` is never called by this project, and the undici advisories all require undici to issue HTTP requests, whereas `src/Flixpatrol/parse.ts:48` and `:283` call `new JSDOM(html)` on already-fetched HTML with no `runScripts` and no `resources: 'usable'`, so jsdom never opens a connection. Real HTTP goes through `impit` and Node's built-in fetch, which uses its own internal undici, not this one.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

lint 0 · typecheck 0 · build 0 · 492 tests pass · coverage 93.62% statements / 87.23% branches. No test changes needed: the bumps are transitive and change no API this project calls.

### One unrelated finding, flagged not fixed

`jsdom@30.0.1` declares `engines: { node: "^22.22.2 || ^24.15.0 || >=26.0.0" }`, and this machine runs **v24.13.1**, so `npm ci` prints an `EBADENGINE` warning. It is a warning, not a failure, and jsdom 30 works fine on 24.13.1 in practice — 492 unit tests plus 103 live XPath assertions passed on it. CI is unaffected since `node-version: 24` resolves to the latest 24.x. Mentioning it because the constraint looks like a Node **security-patch floor**, and the `pkg` targets (`node24-*`) embed whatever Node version `@yao-pkg/pkg-fetch` ships, which nobody has pinned against that floor.
