### PR TITLE
fix(floppy): retry transient 5xx to survive SQLite writer lock contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,23 @@ jobs:
           E2E_FLOPPY_URL: http://127.0.0.1:${{ env.FLOPPY_PORT }}
         run: npm run test:e2e
 
+      # With DEBUG=False, Floppy answers `Internal server error.` and hides the cause
+      # (api/middleware.py), but logs the traceback first — so it only ever exists here.
+      # It is surfaced on its own because it does not fit in a tail: measured on two real
+      # failures, it landed 304 and 322 lines from the end of a ~1300-line log, which a
+      # bare `--tail 200` truncated. stderr is merged in because that is where Django
+      # writes it, and it would otherwise bypass the filter.
       - name: Dump Floppy logs on failure
         if: failure()
-        run: docker logs --tail 200 "$FLOPPY_CONTAINER"
+        run: |
+          echo "::group::Unhandled API exceptions (the cause the HTTP response hides)"
+          docker logs "$FLOPPY_CONTAINER" 2>&1 \
+            | grep -A 40 "Unhandled exception during API request" \
+            || echo "No unhandled API exception logged."
+          echo "::endgroup::"
+          echo "::group::Last 400 log lines"
+          docker logs --tail 400 "$FLOPPY_CONTAINER" 2>&1
+          echo "::endgroup::"
 
       - name: Tear down
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Between lists, an abort checkpoint honours `SIGTERM`/`SIGINT` — it stops only 
 - `ResolutionCache` is a second cache layer, namespaced per backend (`resolution-<backend>/`), so switching backends never re-scrapes a FlixPatrol detail page
 - Adapter-specific behaviour worth remembering: Floppy ignores `privacy` (its API cannot set list visibility) and writes no description (it exposes `latest_update` natively); mdblist writes no description either (`last_updated_at` is native) and forces `sort_by_score=true` on search because the default ranking is poor
 - Neither `FloppyTarget.pickBest` nor `MdblistTarget.pickBest` has a last-resort fallback on the first usable result. Falling through the whole cascade (title+year → title → year) means nothing matched, so any remaining result is a mismatch by definition: they return `null`, the caller warns and drops the item. `TraktTarget` is the exception, because `TraktAPI.getFirstItemByQuery` does fall back to `items[0]`
-- In `FloppyTarget.addItem`, the `PUT` is attempted **first, before any catalogue creation**. This is a data-safety guarantee, not an optimisation: the cleanup `DELETE` can then only ever remove a tracking row this run created, never a status or rating the user entered by hand
+- In `FloppyTarget.addItem`, the `PUT` is attempted **first, before any catalogue creation**. This is a data-safety guarantee, not an optimisation: the cleanup `DELETE` can then only ever remove a tracking row this run created, never a status or rating the user entered by hand. The 5xx retry in `request` does not weaken it: a retried `PUT` that ends up on a 404 still proves the media is absent from the catalogue, so there is no user state to lose
 - `MdblistTarget` memoizes the user list index (`GET /lists/user` returns the WHOLE collection, so one call answers every list lookup) as a `name -> id` map. The memo is **scoped to one run**: `connect()` drops it, because the adapter is built once per process by `app.ts` and shared by every daemon tick — a memo living for the instance lifetime would go stale between two ticks hours apart, and a list deleted from the mdblist web UI in the meantime would still look present, so the adapter would write to a dead id. A miss on an *already populated* memo re-fetches once before concluding the list is absent, since creating a duplicate is a visibly wrong outcome on a backend capped at four static lists
 
 **`src/Scheduler/Scheduler.ts`** - Daemon mode:
@@ -455,9 +455,21 @@ unchanged. What disappeared with the fused write is the *duplicated* per-list wo
 twice, which removes two wasted seconds per list. `users.list.items.get` is genuinely filtered by
 type on the Trakt side, so it legitimately stays one call per kind.
 
-The other two backends do not sleep. Floppy is self-hosted, so a per-item delay would make a
-ten-item list absurdly slow. mdblist writes in bulk instead, and reports its remaining daily
+The other two backends do not sleep between calls. Floppy is self-hosted, so a per-item delay
+would make a ten-item list absurdly slow; it sleeps only to back off a retry (250ms/500ms/1s, see
+below), never on the happy path. mdblist writes in bulk instead, and reports its remaining daily
 budget through `x-ratelimit-remaining`, which `MdblistTarget` logs after each list write.
+
+`FloppyTarget.request` retries **5xx only** (500/502/503/504), 3 attempts max. Floppy on SQLite —
+the self-hosted default — answers 500 when a write loses the race for the single writer lock:
+`api/views.py` does `user_list.items.add(item)` without catching `OperationalError`, and its
+middleware turns the `database is locked` into an opaque `Internal server error.` Measured against
+a real instance while pushing a 25-item list: 11 lock contentions in one run, one of which
+surfaced as a 500 and failed the run. Every verb used here is idempotent (`PUT` accepts 200/409,
+`DELETE` 204/404), so replaying is safe. A **4xx is never retried**: it carries meaning, and the
+404 of the first `PUT` is what drives the `addItem` bootstrap. The backoff is deliberately shorter
+than FlixPatrol's 1s/2s/4s — what is waited out is a lock held for milliseconds, not a remote site
+under load.
 
 ### Logging
 

--- a/src/Targets/adapters/FloppyTarget.ts
+++ b/src/Targets/adapters/FloppyTarget.ts
@@ -1,4 +1,4 @@
-import { FloppyError, logger } from '../../Utils';
+import { FloppyError, logger, Utils } from '../../Utils';
 import type { CacheOptions, FloppyOptions } from '../../types';
 import type {
   ListContent, ListPrivacy, ListTarget, MediaItem, MediaKind, TargetBackend,
@@ -30,6 +30,13 @@ interface FloppyListItem {
 }
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+const RETRY_STATUS_CODES = new Set([500, 502, 503, 504]);
+const MAX_RETRIES = 3;
+// Shorter than the FlixPatrol backoff (1s/2s/4s) on purpose: what is being waited out
+// here is a SQLite writer lock, held for tens to hundreds of milliseconds, not a remote
+// site under load.
+const RETRY_BACKOFF_MS = [250, 500, 1000];
 
 /** Extracts the `results` array of a paginated response, assuming nothing about the rest of the envelope. */
 const readResults = (payload: unknown): unknown[] => {
@@ -166,10 +173,15 @@ export class FloppyTarget implements ListTarget {
 
   /**
    * Single point of passage to the API. Any status outside `expected` throws a
-   * FloppyError.
+   * FloppyError, except a retryable 5xx, which is attempted again.
    *
    * Unlike the Trakt path there is no delay between calls: the server is self-hosted,
    * so the per-item sleep rate limits exist to respect would only slow it down.
+   *
+   * A 5xx is retried because Floppy on SQLite — the self-hosted default — answers 500
+   * when a write loses the race for the single writer lock, and every verb used here is
+   * idempotent (`PUT` accepts 200/409, `DELETE` 204/404). A 4xx is never retried: it
+   * carries meaning, and the 404 of the first `PUT` is what drives `addItem`.
    */
   private async request(
     method: HttpMethod,
@@ -180,23 +192,38 @@ export class FloppyTarget implements ListTarget {
     const headers: Record<string, string> = { 'X-API-Key': this.apiKey };
     if (body !== undefined) headers['Content-Type'] = 'application/json';
 
-    let response: Response;
-    try {
-      response = await fetch(`${this.url}${path}`, {
-        method,
-        headers,
-        body: body === undefined ? undefined : JSON.stringify(body),
-      });
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : `${error}`;
-      throw new FloppyError(`${method} ${path} failed: ${reason}`);
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+      let response: Response;
+      try {
+        response = await fetch(`${this.url}${path}`, {
+          method,
+          headers,
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : `${error}`;
+        throw new FloppyError(`${method} ${path} failed: ${reason}`);
+      }
+
+      const payload = await readPayload(response);
+      if (expected.includes(response.status)) {
+        return { status: response.status, payload };
+      }
+
+      const reason = `${response.status}${detailOf(payload, 'detail')}`;
+      if (!RETRY_STATUS_CODES.has(response.status)) {
+        throw new FloppyError(`${method} ${path} returned ${reason}`);
+      }
+      if (attempt === MAX_RETRIES) {
+        logger.error(`Giving up on ${method} ${path} after ${MAX_RETRIES} attempts: ${reason}`);
+        throw new FloppyError(`${method} ${path} returned ${reason}`);
+      }
+      logger.warn(`Retry attempt ${attempt} for ${method} ${path}: ${reason}`);
+      await Utils.sleep(RETRY_BACKOFF_MS[attempt - 1]);
     }
 
-    const payload = await readPayload(response);
-    if (!expected.includes(response.status)) {
-      throw new FloppyError(`${method} ${path} returned ${response.status}${detailOf(payload, 'detail')}`);
-    }
-    return { status: response.status, payload };
+    // Unreachable: the loop either returns or throws on its last attempt.
+    throw new FloppyError(`${method} ${path} exhausted its attempts`);
   }
 
   /**

--- a/tests/Targets/adapters/FloppyTarget.test.ts
+++ b/tests/Targets/adapters/FloppyTarget.test.ts
@@ -252,8 +252,12 @@ describe('FloppyTarget', () => {
     expect(writes).toHaveLength(0);
   });
 
-  it('raises a FloppyError when the server fails', async () => {
-    fetchMock.mockResolvedValueOnce(json({ detail: 'boom' }, 500));
+  // A server failing every attempt, not just the first: a 5xx is retried, so the
+  // failure surfaces once the attempts are exhausted.
+  it('raises a FloppyError when the server keeps failing', async () => {
+    vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    fetchMock.mockResolvedValue(json({ detail: 'boom' }, 500));
     await expect(target.pushToList({ movie: ['tmdb:1'] }, 'my-list', 'public')).rejects.toThrow(FloppyError);
   });
 });
@@ -368,6 +372,83 @@ describe('FloppyTarget pagination', () => {
       }));
 
     await expect(target.pushToList({ movie: ['tmdb:3'] }, 'my-list', 'public')).rejects.toThrow(FloppyError);
+  });
+
+  /**
+   * Floppy on SQLite (the self-hosted default) answers 500 when a write loses the
+   * race for the single writer lock: `items.add` raises `database is locked` and the
+   * view does not catch it. Observed against a real instance while pushing a 25-item
+   * list, one failure out of 11 lock contentions in a single run. Retrying is what
+   * separates a transient contention from a broken backend.
+   */
+  describe('retry on transient server errors', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+      vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries a 500 and succeeds when the retry does', async () => {
+      fetchMock
+        .mockResolvedValueOnce(json({ detail: 'Internal server error.' }, 500))
+        .mockResolvedValueOnce(json({ results: [] }));
+
+      const pending = target.resolveMany([{ title: 'X', year: 2000 }], 'movie');
+      await vi.runAllTimersAsync();
+
+      expect(await pending).toEqual([]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up with a FloppyError once the attempts are exhausted', async () => {
+      fetchMock.mockResolvedValue(json({ detail: 'Internal server error.' }, 500));
+
+      // The assertion is attached BEFORE the timers advance, otherwise the rejection
+      // lands with no handler and vitest reports an unhandled error.
+      const assertion = expect(
+        target.resolveMany([{ title: 'X', year: 2000 }], 'movie'),
+      ).rejects.toThrow(FloppyError);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    /**
+     * 404 and 409 carry meaning for the caller: a 404 is what proves a media is absent
+     * from the catalogue and drives the bootstrap in `addItem`. Retrying them would
+     * waste requests and delay the sequence that depends on them.
+     */
+    it('never retries a 4xx, which is business meaning rather than a fault', async () => {
+      fetchMock.mockResolvedValue(json({ detail: 'Not found.' }, 404));
+
+      const assertion = expect(
+        target.pushToList({ movie: ['tmdb:1'] }, 'my-list', 'public'),
+      ).rejects.toThrow(FloppyError);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries 502, 503 and 504 as well', async () => {
+      for (const status of [502, 503, 504]) {
+        fetchMock.mockReset();
+        fetchMock
+          .mockResolvedValueOnce(json({ detail: 'nope' }, status))
+          .mockResolvedValueOnce(json({ results: [] }));
+
+        const pending = target.resolveMany([{ title: 'X', year: 2000 }], 'movie');
+        await vi.runAllTimersAsync();
+        await pending;
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      }
+    });
   });
 
   it('gives up instead of looping forever when the cursor never ends', async () => {


### PR DESCRIPTION
## Description

Retries transient 5xx responses in `FloppyTarget.request`, fixing the intermittent `E2E - Floppy` failure — and, more importantly, the real-world failure it was a symptom of.

### Root cause

The flake was a **SQLite writer lock contention**, not a bug in this project. Reproduced on the first try with a fresh container, and the traceback that `api/middleware.py` normally hides:

```
sqlite3.OperationalError: database is locked
  File "/floppy/api/views.py", line 1725, in put
    user_list.items.add(item)
```

What makes it intermittent:

- Floppy starts background jobs that write heavily (`discover_row_built`, `discover_row_cache_write_failed … error=database is locked` — its own workers hit the same contention and *do* catch it).
- The failing test pushes 25+5 uncatalogued media, so 30 four-call bootstraps back to back. Every other Floppy test does exactly one, which is why only this one flakes.
- SQLite allows a single writer. `MediaListDetailView.put` reads first (`prefetch_related("items")`, then `exists()`) and then writes, so it needs a **lock upgrade** — and SQLite returns `SQLITE_BUSY` immediately on an upgrade when another writer is active, bypassing `busy_timeout` to avoid a deadlock. Measured: the 500 lands **2 seconds** after the 404, not after the configured 30s timeout, which is what rules the timeout out.
- The view does not catch `OperationalError`, so the middleware converts it to an opaque `Internal server error.` — with `DEBUG=False`, the real message is replaced, which is why this needed a live reproduction to diagnose at all.

In one run: **11 lock contentions, 1 escaped as a 500** and failed the suite.

### Why this is a product fix and not a test workaround

`Floppy on SQLite` is the self-hosted default. Any user pushing a 20-item list while their instance is doing anything else can take the same 500, and `addItem` fails the entire run on it. The flaky test was the messenger.

### The change

`FloppyTarget.request` now retries 5xx: `{500, 502, 503, 504}`, 3 attempts, backoff 250ms/500ms/1s.

- **4xx is never retried.** It carries meaning — the 404 of the first `PUT` is precisely what drives the `addItem` bootstrap — and retrying it would waste requests and delay the sequence depending on it. Pinned by a test.
- **Replaying is safe**: every verb used here is idempotent (`PUT` accepts 200/409, `DELETE` 204/404).
- **The data-safety guarantee still holds.** A retried `PUT` that ends up on a 404 still proves the media is absent from the catalogue, so the cleanup `DELETE` still cannot erase a hand-entered watch status or rating.
- The backoff is shorter than FlixPatrol's 1s/2s/4s on purpose: what is waited out is a lock held for milliseconds, not a remote site under load.

### Verification against a real instance

Three fresh containers, three green suites (7/7 each). The third one exercised the fix on the exact failing scenario — from Floppy's own access log:

```
09:37:43  PUT  …/1170824/lists/4/  → 404   (probe, media absent from catalogue)
09:37:43  PUT  …/1170824/lists/4/  → 500   ← database is locked
09:37:44  PUT  …/1170824/lists/4/  → 200   ← the retry, succeeded
09:37:44  DELETE …/1170824/         → 204   (tracking cleanup, as designed)
```

The contention has not disappeared (4 `database is locked` in that run) — it is now absorbed.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

4 tests added (retry then succeed, give up after exhausting attempts, never retry a 4xx, cover 502/503/504), written before the implementation and confirmed failing first. **496 tests pass**, up from 492. lint 0 · typecheck 0 · build 0 · coverage 93.61% statements / 87.29% branches.

One pre-existing test changed: `raises a FloppyError when the server fails` mocked a single 500 with `mockResolvedValueOnce`. Its intent is unchanged — a failing server still raises — but it now surfaces once the attempts are exhausted, so the mock covers every attempt and the name says "keeps failing".

### CI diagnosability (second commit)

**Correcting something I got wrong earlier in this PR's history:** I claimed the `e2e-floppy` job did not capture Floppy's logs. It did — a `Dump Floppy logs on failure` step with `if: failure()` has been there all along. I had read the CI output with `gh run view --log-failed`, which only shows *failing* steps, and that step succeeds (it merely prints), so it never appeared in what I looked at.

What is real, and measured, is that it was **mis-calibrated for this exact failure**. It ran `docker logs --tail 200`, and on the two real failures captured here the traceback landed **304 and 322 lines from the end** of a ~1300-line log — truncated both times. The traceback is the only place the cause exists, since `api/middleware.py` replaces it with `Internal server error.` when `DEBUG=False`.

So the step now surfaces the exceptions on their own, ahead of a wider tail:

- greps `Unhandled exception during API request` with 40 lines of context, inside a collapsible `::group::`
- merges stderr (`2>&1`), which is where Django writes those lines and where they would otherwise bypass the filter
- falls back to an explicit "none" message, so the `bash -e` GitHub uses does not fail the step when grep matches nothing
- keeps a `--tail 400` for general context

Verified by replaying the step's logic against both captured logs: the failing one yields 43 lines containing `database is locked` and the offending `items.add`, the clean one prints the fallback and exits 0.

## Note left deliberately undone

**The upstream bug remains.** The real fix belongs in Floppy: `MediaListDetailView.put` should catch `OperationalError` and retry, exactly as its own background workers already do for the same error. Not reported yet.

## Related Issues

None — found while reviewing the `E2E - Floppy` failure on #526.
