### PR TITLE
fix(floppy): never replay the non-idempotent list creation, recover it by name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,11 +468,21 @@ the self-hosted default — answers 500 when a write loses the race for the sing
 `api/views.py` does `user_list.items.add(item)` without catching `OperationalError`, and its
 middleware turns the `database is locked` into an opaque `Internal server error.` Measured against
 a real instance while pushing a 25-item list: 11 lock contentions in one run, one of which
-surfaced as a 500 and failed the run. Every verb used here is idempotent (`PUT` accepts 200/409,
-`DELETE` 204/404), so replaying is safe. A **4xx is never retried**: it carries meaning, and the
-404 of the first `PUT` is what drives the `addItem` bootstrap. The backoff is deliberately shorter
-than FlixPatrol's 1s/2s/4s — what is waited out is a lock held for milliseconds, not a remote site
-under load.
+surfaced as a 500 and failed the run. Every verb routed through `request` is idempotent (`PUT`
+accepts 200/409, `DELETE` 204/404), so replaying is safe. A **4xx is never retried**: it carries
+meaning, and the 404 of the first `PUT` is what drives the `addItem` bootstrap. The backoff is
+deliberately shorter than FlixPatrol's 1s/2s/4s — what is waited out is a lock held for
+milliseconds, not a remote site under load.
+
+**The one call that must never be replayed is list creation**, and it is the reason `request` is a
+thin retry wrapper over `requestOnce` rather than one method: `POST /api/v1/lists/` is *not*
+idempotent — three identical posts create three lists with three distinct ids, measured against a
+real instance. Under writer-lock contention a 500 can land *after* the row was committed, so the
+retry introduced with the paragraph above turned one contention into a duplicate list. So
+`getOrCreateList` calls `requestOnce`, and on failure **re-reads by name before giving up**: the
+list the failed `POST` committed anyway is adopted, and only a name that is still absent rethrows
+the original error. That recovery is also what makes a *transport* failure survivable — a response
+lost on the wire looks identical to a creation that never happened.
 
 ### Logging
 

--- a/src/Targets/adapters/FloppyTarget.ts
+++ b/src/Targets/adapters/FloppyTarget.ts
@@ -174,18 +174,13 @@ export class FloppyTarget implements ListTarget {
   }
 
   /**
-   * Single point of passage to the API. Any status outside `expected` throws a
-   * FloppyError, except a retryable 5xx, which is attempted again.
+   * Single point of passage to the API, one attempt only. Any status outside `expected`
+   * throws a FloppyError carrying that status.
    *
    * Unlike the Trakt path there is no delay between calls: the server is self-hosted,
    * so the per-item sleep rate limits exist to respect would only slow it down.
-   *
-   * A 5xx is retried because Floppy on SQLite — the self-hosted default — answers 500
-   * when a write loses the race for the single writer lock, and every verb used here is
-   * idempotent (`PUT` accepts 200/409, `DELETE` 204/404). A 4xx is never retried: it
-   * carries meaning, and the 404 of the first `PUT` is what drives `addItem`.
    */
-  private async request(
+  private async requestOnce(
     method: HttpMethod,
     path: string,
     body?: unknown,
@@ -194,34 +189,57 @@ export class FloppyTarget implements ListTarget {
     const headers: Record<string, string> = { 'X-API-Key': this.apiKey };
     if (body !== undefined) headers['Content-Type'] = 'application/json';
 
+    let response: Response;
+    try {
+      response = await fetch(`${this.url}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : `${error}`;
+      throw new FloppyError(`${method} ${path} failed: ${reason}`);
+    }
+
+    const payload = await readPayload(response);
+    if (expected.includes(response.status)) {
+      return { status: response.status, payload };
+    }
+
+    const reason = `${response.status}${detailOf(payload, 'detail')}`;
+    throw new FloppyError(`${method} ${path} returned ${reason}`, response.status);
+  }
+
+  /**
+   * `requestOnce` with a retry on transient 5xx.
+   *
+   * A 5xx is retried because Floppy on SQLite — the self-hosted default — answers 500
+   * when a write loses the race for the single writer lock, and every verb routed here is
+   * idempotent (`PUT` accepts 200/409, `DELETE` 204/404). List creation is not, and goes
+   * through `requestOnce` instead. A 4xx is never retried: it carries meaning, and the
+   * 404 of the first `PUT` is what drives `addItem`.
+   */
+  private async request(
+    method: HttpMethod,
+    path: string,
+    body?: unknown,
+    expected: number[] = [200],
+  ): Promise<{ status: number; payload: unknown }> {
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
-      let response: Response;
       try {
-        response = await fetch(`${this.url}${path}`, {
-          method,
-          headers,
-          body: body === undefined ? undefined : JSON.stringify(body),
-        });
+        return await this.requestOnce(method, path, body, expected);
       } catch (error) {
-        const reason = error instanceof Error ? error.message : `${error}`;
-        throw new FloppyError(`${method} ${path} failed: ${reason}`);
-      }
+        const status = error instanceof FloppyError ? error.status : undefined;
+        if (status === undefined || !RETRY_STATUS_CODES.has(status)) throw error;
 
-      const payload = await readPayload(response);
-      if (expected.includes(response.status)) {
-        return { status: response.status, payload };
+        const reason = (error as Error).message;
+        if (attempt === MAX_RETRIES) {
+          logger.error(`Giving up on ${method} ${path} after ${MAX_RETRIES} attempts: ${reason}`);
+          throw error;
+        }
+        logger.warn(`Retry attempt ${attempt} for ${method} ${path}: ${reason}`);
+        await Utils.sleep(RETRY_BACKOFF_MS[attempt - 1]);
       }
-
-      const reason = `${response.status}${detailOf(payload, 'detail')}`;
-      if (!RETRY_STATUS_CODES.has(response.status)) {
-        throw new FloppyError(`${method} ${path} returned ${reason}`, response.status);
-      }
-      if (attempt === MAX_RETRIES) {
-        logger.error(`Giving up on ${method} ${path} after ${MAX_RETRIES} attempts: ${reason}`);
-        throw new FloppyError(`${method} ${path} returned ${reason}`, response.status);
-      }
-      logger.warn(`Retry attempt ${attempt} for ${method} ${path}: ${reason}`);
-      await Utils.sleep(RETRY_BACKOFF_MS[attempt - 1]);
     }
 
     // Unreachable: the loop either returns or throws on its last attempt.
@@ -323,21 +341,40 @@ export class FloppyTarget implements ListTarget {
     return best === null ? null : FloppyTarget.encodeId(best.source, best.media_id);
   }
 
-  private async getOrCreateList(listName: string): Promise<number> {
+  /** The id of the list named exactly `listName`, or null when no such list exists. */
+  private async findListByName(listName: string): Promise<number | null> {
     // Floppy's `search` is a partial match, which forces both of the next two lines:
     // read every page, since a name sharing a substring with many others can push the
     // exact match past page one and make it look absent, then require strict equality
     // so "netflix-france-top10-kids" is not reused for "netflix-france-top10".
     const found = await this.requestAllPages(`/api/v1/lists/?search=${encodeURIComponent(listName)}`);
     const exact = FloppyTarget.readLists(found).find((l) => l.name === listName);
-    if (exact) return exact.id;
+    return exact ? exact.id : null;
+  }
+
+  private async getOrCreateList(listName: string): Promise<number> {
+    const existing = await this.findListByName(listName);
+    if (existing !== null) return existing;
 
     if (this.dryRun) {
       logger.info(`[DRY-RUN] Would create Floppy list "${listName}"`);
       return 0;
     }
     logger.warn(`List "${listName}" was not found on Floppy, creating it`);
-    const created = await this.request('POST', '/api/v1/lists/', { name: listName }, [200, 201]);
+
+    let created: { payload: unknown };
+    try {
+      // `requestOnce`, never `request`: creation is the only non-idempotent call of this
+      // adapter, and under writer-lock contention a 500 can land after the row was
+      // committed, so replaying it creates a duplicate list.
+      created = await this.requestOnce('POST', '/api/v1/lists/', { name: listName }, [200, 201]);
+    } catch (error) {
+      const committed = await this.findListByName(listName);
+      if (committed === null) throw error;
+      logger.warn(`Creating "${listName}" reported ${(error as Error).message}, but the list exists: reusing it`);
+      return committed;
+    }
+
     const list = FloppyTarget.toList(created.payload);
     if (list === null) throw new FloppyError(`Failed to create list "${listName}"`);
     return list.id;

--- a/tests/Targets/adapters/FloppyTarget.test.ts
+++ b/tests/Targets/adapters/FloppyTarget.test.ts
@@ -451,6 +451,59 @@ describe('FloppyTarget pagination', () => {
     });
   });
 
+  /**
+   * `POST /api/v1/lists/` is the one call here that is not idempotent: three identical
+   * posts create three lists. Under writer-lock contention a 500 can land after the row
+   * was committed, so the retry of #533 turned one contention into a duplicate list.
+   */
+  describe('list creation, which cannot be replayed', () => {
+    beforeEach(() => {
+      vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+      vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    });
+
+    const creations = (mock: ReturnType<typeof vi.fn>) => mock.mock.calls
+      .filter((c) => c[1]?.method === 'POST' && c[0] === 'http://floppy:8000/api/v1/lists/');
+
+    it('posts the creation once and only once when it answers 500', async () => {
+      fetchMock
+        .mockResolvedValueOnce(json({ results: [] })) // lookup: absent
+        .mockResolvedValueOnce(json({ detail: 'Internal server error.' }, 500))
+        .mockResolvedValueOnce(json({ results: [] })); // re-read: nothing was committed
+
+      await expect(target.pushToList({ movie: ['tmdb:1'] }, 'my-list', 'public'))
+        .rejects.toThrow(FloppyError);
+
+      expect(creations(fetchMock)).toHaveLength(1);
+    });
+
+    it('adopts the list a failed creation had committed anyway', async () => {
+      fetchMock
+        .mockResolvedValueOnce(json({ results: [] })) // lookup: absent
+        .mockResolvedValueOnce(json({ detail: 'Internal server error.' }, 500))
+        .mockResolvedValueOnce(json({ results: [{ id: 27, name: 'my-list' }] })) // it exists
+        .mockResolvedValueOnce(json({ results: [] })) // items read
+        .mockResolvedValueOnce(json([{ list_id: 27 }]));
+
+      await target.pushToList({ movie: ['tmdb:1'] }, 'my-list', 'public');
+
+      expect(creations(fetchMock)).toHaveLength(1);
+      expect(urlOf(fetchMock, 4)).toBe('http://floppy:8000/api/v1/media/movie/tmdb/1/lists/27/');
+    });
+
+    // The re-read only rescues a name that now exists: a creation refused outright must
+    // still fail the run rather than be swallowed.
+    it('reports the original failure when the re-read finds nothing', async () => {
+      fetchMock
+        .mockResolvedValueOnce(json({ results: [] }))
+        .mockResolvedValueOnce(json({ detail: 'Internal server error.' }, 500))
+        .mockResolvedValueOnce(json({ results: [] }));
+
+      await expect(target.pushToList({ movie: ['tmdb:1'] }, 'my-list', 'public'))
+        .rejects.toThrow(/500: Internal server error\./);
+    });
+  });
+
   it('gives up instead of looping forever when the cursor never ends', async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/api/v1/lists/?search=')) return page(null, [{ id: 7, name: 'my-list' }]);


### PR DESCRIPTION
## Description

#533 put a 5xx retry in `FloppyTarget.request`, and claimed "every verb used here is idempotent".
That was true of the verbs `addItem` uses. It is **not** true of `POST /api/v1/lists/`, which also
goes through `request`: three identical posts create three lists with three distinct ids, measured
against a real instance. Under the very SQLite writer-lock contention #533 exists to survive, a 500
can land *after* the row was committed — so the retry turns one contention into a duplicate list.

The fix, in two parts:

- `request` becomes a thin retry wrapper over a new `requestOnce`, which is one attempt and nothing
  else. `getOrCreateList` calls `requestOnce`, so **creation is never replayed**. Every other call
  keeps the retry it got in #533, unchanged.
- On a failed creation, the list is **re-read by name before giving up**: the list a 500 committed
  anyway is adopted, and only a name that is still absent rethrows the original error. This also
  covers a response lost on the wire, which is indistinguishable from a creation that never
  happened.

The name lookup was extracted to `findListByName` so both the initial lookup and the recovery share
the exact-match rules (read every page, strict equality) rather than duplicating them.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

Three tests added, each watched failing first: the creation is posted exactly once on a 500; a list
the failed creation committed is adopted instead of duplicated; a re-read that finds nothing still
fails the run with the original error. `CLAUDE.md` is corrected — it asserted the opposite.

## Related Issues

Fixes the regression introduced by #533.
