### PR TITLE
chore: ignore the vitest 5 cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ config/local.json
 .trakt
 .cache/
 .reports/
+.vitest/
 docker-compose.yml
 .env.e2e


### PR DESCRIPTION
## Description

Vitest 5 (merged in #540) writes a cache directory at `.vitest/` in the repository root.
The `.gitignore` only covered `.cache/` and `.reports/`, so the directory showed up as
untracked after every test run.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

## Related Issues
Follow-up to #540
