### PR TITLE
chore(renovate): label every dependency PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   "baseBranchPatterns": [
     "develop"
   ],
+  "labels": ["dependencies"],
   "schedule": ["before 6am on monday"],
   "platformAutomerge": false,
   "automergeSchedule": ["at any time"],


### PR DESCRIPTION
## Description

Renovate opened its pull requests with no label, so `release-changelog-builder-action` — which
categorises purely by label — dropped every dependency update from the generated changelog. Seven
of them had to be labelled by hand before tagging 3.0.0 (#526, #528, #529, #537, #538, #539, #540).

A root-level `labels` applies to every branch Renovate raises, whatever the `packageRules` group it
lands in.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [ ] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Tests pass (`npm test`)

## Related Issues
Follow-up to the 3.0.0 release
